### PR TITLE
Fix pageIdx < numPages assertion crash on database reopen (#1)

### DIFF
--- a/Sources/cxx-kuzu/kuzu/src/include/storage/file_handle.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/storage/file_handle.h
@@ -110,6 +110,11 @@ public:
 
     PageManager* getPageManager() { return pageManager.get(); }
 
+    // Re-reads the file size from disk and updates numPages, pageCapacity,
+    // pageStates, and frameGroupIdxes. Used after shadow pages are applied
+    // directly to the data file so that the FileHandle reflects the new size.
+    void refreshNumPagesFromDisk();
+
 private:
     bool isLargePaged() const { return fhFlags & isLargePagedMask; }
     bool isNewTmpFile() const { return fhFlags & isNewInMemoryTmpFileMask; }

--- a/Sources/cxx-kuzu/kuzu/src/storage/file_handle.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/file_handle.cpp
@@ -174,5 +174,27 @@ void FileHandle::writePagesToFile(const uint8_t* buffer, uint64_t size,
     }
 }
 
+void FileHandle::refreshNumPagesFromDisk() {
+    std::unique_lock lck{fhSharedMutex, std::defer_lock_t{}};
+    while (!lck.try_lock()) {}
+    KU_ASSERT(fileInfo);
+    const auto fileLength = fileInfo->getFileSize();
+    const auto newNumPages =
+        static_cast<uint32_t>(ceil(static_cast<double>(fileLength) /
+                                   static_cast<double>(getPageSize())));
+    if (newNumPages <= numPages) {
+        return;
+    }
+    // Grow pageCapacity and register new frame groups as needed.
+    while (pageCapacity < newNumPages) {
+        addNewPageGroupWithoutLock();
+    }
+    // Reset page states for the new pages so they start as evicted.
+    for (auto i = numPages; i < newNumPages; i++) {
+        pageStates[i].resetToEvicted();
+    }
+    numPages = newNumPages;
+}
+
 } // namespace storage
 } // namespace kuzu

--- a/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
@@ -35,6 +35,13 @@ StorageManager::StorageManager(const std::string& databasePath, bool readOnly,
 StorageManager::~StorageManager() = default;
 
 void StorageManager::initDataFileHandle(VirtualFileSystem* vfs, main::ClientContext* context) {
+    if (dataFH) {
+        // During recovery, the FileHandle already exists. Instead of creating a
+        // duplicate (which would get a different fileIndex in BufferManager),
+        // just refresh numPages from the actual file size on disk.
+        dataFH->refreshNumPagesFromDisk();
+        return;
+    }
     if (inMemory) {
         dataFH = memoryManager.getBufferManager()->getFileHandle(databasePath,
             FileHandle::O_PERSISTENT_FILE_IN_MEM, vfs, context);

--- a/Sources/cxx-kuzu/kuzu/src/storage/wal/wal_replayer.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/wal/wal_replayer.cpp
@@ -74,6 +74,10 @@ protected:
         shadowFile.flushAll();
         // Apply shadow pages directly to the data file WITHOUT logging to WAL.
         shadowFile.applyShadowPages(clientContext);
+        // Refresh the data file handle's numPages so it reflects any pages that
+        // were extended by applyShadowPages writing beyond the previous file size.
+        auto* dataFH = clientContext.getStorageManager()->getDataFH();
+        dataFH->refreshNumPagesFromDisk();
         // Clear shadow file buffers so they can be reused for the next transaction.
         auto bufferManager = clientContext.getMemoryManager()->getBufferManager();
         shadowFile.clear(*bufferManager);


### PR DESCRIPTION
Fixes #1 — `pageIdx < numPages` assertion crash when reopening a database after auto-checkpoint.

## Root Cause

1. `applyShadowPages()` grows the data file but `FileHandle.numPages` stays stale
2. `readCheckpoint()` creates duplicate FileHandles during recovery

## Changes (4 files, ~38 lines)

- `file_handle.h/.cpp` — Added `refreshNumPagesFromDisk()` method
- `wal_replayer.cpp` — Call refresh after `applyShadowPages()` in RecoveryCheckpointer
- `storage_manager.cpp` — Reuse existing FileHandle in `initDataFileHandle()` during recovery

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author