### PR TITLE
fix: clear tables before deserialize during recovery (#1)

### DIFF
--- a/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
@@ -248,6 +248,7 @@ void StorageManager::serialize(const Catalog& catalog, Serializer& ser) {
 
 void StorageManager::deserialize(main::ClientContext* context, const Catalog* catalog,
     Deserializer& deSer) {
+    tables.clear();
     std::string key;
     deSer.validateDebuggingInfo(key, "num_node_tables");
     uint64_t numNodeTables = 0;


### PR DESCRIPTION
Fixes query failures (`KuzuError error 2`) after database reopen — follow-up to #2.

## Root Cause

`StorageManager::deserialize()` is called multiple times during WAL recovery (once per intermediate checkpoint via `readCheckpoint()`). On the second+ call, the `tables` map already has entries from the previous cycle:
- **Debug mode**: `KU_ASSERT(!tables.contains(tableID))` crashes
- **Release mode**: Tables silently overwritten → dangling references → query failures

## Fix

Add `tables.clear()` at the start of `StorageManager::deserialize()`. This is safe because:
- First load: tables is empty, `clear()` is a no-op
- Recovery reload: stale entries are properly destroyed before fresh ones are created

## Changes

1 file, 1 line added: `Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author