### PR TITLE
refactor: remove readCheckpoint from recovery path + revert unnecessary patches

### DIFF
--- a/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
@@ -35,13 +35,6 @@ StorageManager::StorageManager(const std::string& databasePath, bool readOnly,
 StorageManager::~StorageManager() = default;
 
 void StorageManager::initDataFileHandle(VirtualFileSystem* vfs, main::ClientContext* context) {
-    if (dataFH) {
-        // During recovery, the FileHandle already exists. Instead of creating a
-        // duplicate (which would get a different fileIndex in BufferManager),
-        // just refresh numPages from the actual file size on disk.
-        dataFH->refreshNumPagesFromDisk();
-        return;
-    }
     if (inMemory) {
         dataFH = memoryManager.getBufferManager()->getFileHandle(databasePath,
             FileHandle::O_PERSISTENT_FILE_IN_MEM, vfs, context);
@@ -248,7 +241,6 @@ void StorageManager::serialize(const Catalog& catalog, Serializer& ser) {
 
 void StorageManager::deserialize(main::ClientContext* context, const Catalog* catalog,
     Deserializer& deSer) {
-    tables.clear();
     std::string key;
     deSer.validateDebuggingInfo(key, "num_node_tables");
     uint64_t numNodeTables = 0;

--- a/Sources/cxx-kuzu/kuzu/src/storage/wal/wal_replayer.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/wal/wal_replayer.cpp
@@ -96,9 +96,6 @@ void WALReplayer::performRecoveryCheckpoint() const {
     try {
         RecoveryCheckpointer checkpointer(clientContext);
         checkpointer.writeRecoveryCheckpoint();
-        // After checkpoint, reload catalog and storage metadata from disk so that
-        // the next transaction's replay sees the freshly checkpointed state.
-        checkpointer.readCheckpoint();
     } catch (const std::exception&) {
         // If the intermediate checkpoint fails, we continue replaying. The data
         // is still safe in the WAL and will be fully replayed. We just won't get

--- a/Tests/kuzu-swiftTests/StressTests.swift
+++ b/Tests/kuzu-swiftTests/StressTests.swift
@@ -573,7 +573,238 @@ final class StressTests: XCTestCase {
         print("[StressTest] Data integrity verified across close/reopen cycles ✓")
     }
 
-    // MARK: - Test 4: Concurrent Queries Under Memory Pressure
+    // MARK: - Test 4: Recovery From Corrupt WAL (SIGKILL Simulation)
+
+    func testRecoveryFromCorruptWAL() throws {
+        let tempDir = NSTemporaryDirectory() + "kuzu_wal_corrupt_" + UUID().uuidString
+        let dbPath = tempDir + "/db"
+        try FileManager.default.createDirectory(
+            atPath: tempDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(atPath: tempDir)
+            print("[StressTest] Cleaned up temp directory")
+        }
+
+        let fm = FileManager.default
+        let overallStart = Date()
+        // WAL file path follows Kuzu convention: {dbPath}.wal
+        let walPath = dbPath + ".wal"
+
+        // ── Session 1: Create clean baseline ──
+        do {
+            let sessionStart = Date()
+            print("[StressTest] Session 1: Creating database and populating baseline data...")
+
+            let config = SystemConfig(
+                bufferPoolSize: 256 * 1024 * 1024,
+                maxNumThreads: 2,
+                autoCheckpoint: true,
+                checkpointThreshold: 16 * 1024 * 1024
+            )
+            let db = try Database(dbPath, config)
+            let conn = try Connection(db)
+
+            // Create schema
+            _ = try conn.query(
+                "CREATE NODE TABLE TestNode(id INT64, data STRING, PRIMARY KEY(id));")
+            print("[StressTest]   Schema created")
+
+            // Insert 500 nodes in batches of 100
+            for batchStart in stride(from: 0, to: 500, by: 100) {
+                let batchEnd = min(batchStart + 100, 500)
+                var rows = [String]()
+                for i in batchStart..<batchEnd {
+                    rows.append("{id: \(i), data: 'node_\(i)'}")
+                }
+                let query = "UNWIND [\(rows.joined(separator: ","))] AS row CREATE (:TestNode {id: row.id, data: row.data});"
+                _ = try conn.query(query)
+            }
+            print("[StressTest]   500 nodes inserted")
+
+            // Force explicit checkpoint
+            _ = try conn.query("CHECKPOINT;")
+            print("[StressTest]   Explicit CHECKPOINT executed")
+
+            // Insert 200 more nodes WITHOUT checkpoint (WAL only)
+            for batchStart in stride(from: 500, to: 700, by: 100) {
+                let batchEnd = min(batchStart + 100, 700)
+                var rows = [String]()
+                for i in batchStart..<batchEnd {
+                    rows.append("{id: \(i), data: 'node_\(i)'}")
+                }
+                let query = "UNWIND [\(rows.joined(separator: ","))] AS row CREATE (:TestNode {id: row.id, data: row.data});"
+                _ = try conn.query(query)
+            }
+            print("[StressTest]   200 more nodes inserted (WAL only, no checkpoint)")
+
+            let sessionElapsed = Date().timeIntervalSince(sessionStart)
+            print("[StressTest] Session 1 complete in \(String(format: "%.1f", sessionElapsed))s")
+        }
+        // DB closes here — forceCheckpointOnClose may checkpoint everything
+
+        // ── Session 2: Corrupt the WAL file to simulate SIGKILL ──
+        do {
+            print("[StressTest] Session 2: Corrupting WAL file to simulate SIGKILL...")
+
+            // Check multiple possible WAL paths
+            var actualWalPath: String? = nil
+            let candidatePaths = [walPath]
+            // Also check inside the DB directory
+            if fm.fileExists(atPath: dbPath) {
+                if let contents = try? fm.contentsOfDirectory(atPath: dbPath) {
+                    for file in contents where file.contains("wal") {
+                        let fullPath = (dbPath as NSString).appendingPathComponent(file)
+                        print("[StressTest]   Found WAL-related file inside DB dir: \(file)")
+                        if actualWalPath == nil {
+                            actualWalPath = fullPath
+                        }
+                    }
+                }
+            }
+            for path in candidatePaths {
+                if fm.fileExists(atPath: path) {
+                    print("[StressTest]   Found WAL file at: \(path)")
+                    actualWalPath = path
+                }
+            }
+
+            if let walFilePath = actualWalPath, let walData = fm.contents(atPath: walFilePath), walData.count > 0 {
+                // Truncate WAL to 50% of original size
+                let originalSize = walData.count
+                let truncatedSize = originalSize / 2
+                let truncatedData = walData.prefix(truncatedSize)
+                try truncatedData.write(to: URL(fileURLWithPath: walFilePath))
+                print("[StressTest]   WAL corrupted: \(originalSize) bytes → \(truncatedSize) bytes (50% truncation)")
+            } else {
+                // WAL was cleared on close (forceCheckpointOnClose=true) or doesn't exist
+                // Create a synthetic corrupt WAL to simulate SIGKILL mid-write
+                print("[StressTest]   WAL file empty or not found after clean close — creating synthetic corrupt WAL")
+                // Write random bytes that look like a partially written WAL
+                var corruptData = Data(count: 4096)
+                corruptData.withUnsafeMutableBytes { ptr in
+                    // Write some header-like bytes then garbage
+                    let bytes = ptr.bindMemory(to: UInt8.self)
+                    for i in 0..<4096 {
+                        bytes[i] = UInt8(i % 256)
+                    }
+                }
+                try corruptData.write(to: URL(fileURLWithPath: walPath))
+                print("[StressTest]   Synthetic corrupt WAL written: 4096 bytes at \(walPath)")
+            }
+        }
+
+        // ── Session 3: Verify recovery (THE KEY TEST) ──
+        do {
+            let sessionStart = Date()
+            print("[StressTest] Session 3: Opening database after WAL corruption...")
+
+            let config = SystemConfig(
+                bufferPoolSize: 256 * 1024 * 1024,
+                maxNumThreads: 2,
+                autoCheckpoint: true,
+                checkpointThreshold: 16 * 1024 * 1024
+            )
+
+            // This MUST NOT throw — if it does, the test fails
+            let db = try Database(dbPath, config)
+            let conn = try Connection(db)
+            print("[StressTest]   Database opened successfully after WAL corruption ✓")
+
+            // Query count — should be >= 500 (checkpointed baseline)
+            let countResult = try conn.query("MATCH (n:TestNode) RETURN count(n);")
+            let countTuple = try countResult.getNext()!
+            let recoveredCount = try countTuple.getValue(0) as! Int64
+            XCTAssertGreaterThanOrEqual(recoveredCount, 500,
+                "Expected at least 500 nodes (checkpointed baseline), got \(recoveredCount)")
+            print("[StressTest]   Recovered node count: \(recoveredCount) (expected >= 500) ✓")
+
+            // Verify a specific checkpointed node
+            let nodeResult = try conn.query("MATCH (n:TestNode {id: 100}) RETURN n.data;")
+            let nodeTuple = try nodeResult.getNext()!
+            let nodeData = try nodeTuple.getValue(0) as? String
+            XCTAssertEqual(nodeData, "node_100", "Expected node_100 data, got \(nodeData ?? "nil")")
+            print("[StressTest]   Node id=100 data: \(nodeData ?? "nil") ✓")
+
+            let sessionElapsed = Date().timeIntervalSince(sessionStart)
+            print("[StressTest] Session 3 complete in \(String(format: "%.1f", sessionElapsed))s")
+        }
+
+        // ── Session 4: Verify DB is usable after recovery ──
+        do {
+            let sessionStart = Date()
+            print("[StressTest] Session 4: Verifying DB is usable after recovery...")
+
+            let config = SystemConfig(
+                bufferPoolSize: 256 * 1024 * 1024,
+                maxNumThreads: 2,
+                autoCheckpoint: true,
+                checkpointThreshold: 16 * 1024 * 1024
+            )
+            let db = try Database(dbPath, config)
+            let conn = try Connection(db)
+
+            // Get count before insert
+            let beforeResult = try conn.query("MATCH (n:TestNode) RETURN count(n);")
+            let beforeTuple = try beforeResult.getNext()!
+            let beforeCount = try beforeTuple.getValue(0) as! Int64
+
+            // Insert 100 new nodes (ids 10000-10099)
+            var rows = [String]()
+            for i in 10000..<10100 {
+                rows.append("{id: \(i), data: 'node_\(i)'}")
+            }
+            let query = "UNWIND [\(rows.joined(separator: ","))] AS row CREATE (:TestNode {id: row.id, data: row.data});"
+            _ = try conn.query(query)
+            print("[StressTest]   100 new nodes inserted (ids 10000-10099)")
+
+            // Verify count increased
+            let afterResult = try conn.query("MATCH (n:TestNode) RETURN count(n);")
+            let afterTuple = try afterResult.getNext()!
+            let afterCount = try afterTuple.getValue(0) as! Int64
+            XCTAssertEqual(afterCount, beforeCount + 100,
+                "Expected count to increase by 100: before=\(beforeCount), after=\(afterCount)")
+            print("[StressTest]   Count increased: \(beforeCount) → \(afterCount) ✓")
+
+            let sessionElapsed = Date().timeIntervalSince(sessionStart)
+            print("[StressTest] Session 4 complete in \(String(format: "%.1f", sessionElapsed))s")
+        }
+
+        // ── Session 5: Final persistence check ──
+        do {
+            let sessionStart = Date()
+            print("[StressTest] Session 5: Final persistence check...")
+
+            let config = SystemConfig(
+                bufferPoolSize: 256 * 1024 * 1024,
+                maxNumThreads: 2,
+                autoCheckpoint: true,
+                checkpointThreshold: 16 * 1024 * 1024
+            )
+            let db = try Database(dbPath, config)
+            let conn = try Connection(db)
+
+            // Verify node from Session 4 persisted
+            let result = try conn.query("MATCH (n:TestNode {id: 10050}) RETURN n.data;")
+            let tuple = try result.getNext()!
+            let data = try tuple.getValue(0) as? String
+            XCTAssertEqual(data, "node_10050", "Expected node_10050 data, got \(data ?? "nil")")
+            print("[StressTest]   Node id=10050 data: \(data ?? "nil") ✓")
+
+            let sessionElapsed = Date().timeIntervalSince(sessionStart)
+            print("[StressTest] Session 5 complete in \(String(format: "%.1f", sessionElapsed))s")
+        }
+
+        let totalElapsed = Date().timeIntervalSince(overallStart)
+        print("\n[StressTest] === CORRUPT WAL RECOVERY TEST SUMMARY ===")
+        print("[StressTest] Total time: \(String(format: "%.1f", totalElapsed))s")
+        print("[StressTest] 5 sessions completed successfully ✓")
+        print("[StressTest] Database recovered from corrupt WAL ✓")
+        print("[StressTest] Data integrity verified after recovery ✓")
+        print("[StressTest] New writes work after recovery ✓")
+        print("[StressTest] Persistence verified after recovery ✓")
+    }
+
+    // MARK: - Test 5: Concurrent Queries Under Memory Pressure
 
     func testConcurrentQueriesUnderMemoryPressure() throws {
         let dbPath = try StressTests.ensureSharedDB()


### PR DESCRIPTION
## Why

`readCheckpoint()` was never designed to be called while the system is running. It destroys and re-creates all Table objects, FileHandles, and catalog entries — which caused 3 separate bugs that each required a patch:

- `refreshNumPagesFromDisk()` in `initDataFileHandle()` — duplicate FileHandle prevention
- `tables.clear()` in `deserialize()` — stale table map entries
- Both were only needed because `readCheckpoint()` was called mid-recovery

## What changed

1. **Removed `readCheckpoint()` from `performRecoveryCheckpoint()`** — after `writeRecoveryCheckpoint()`, the in-memory state is already correct. No need to reload from disk.
2. **Reverted `initDataFileHandle()` reuse guard** — no longer called during recovery
3. **Reverted `tables.clear()` in `deserialize()`** — no longer called during recovery

## What's kept

- `refreshNumPagesFromDisk()` method + call in `RecoveryCheckpointer::logCheckpointAndApplyShadowPages()` — still needed because `applyShadowPages()` extends the file
- Corrupt WAL recovery catch block in `replay()` — still needed as SIGKILL safety net

## Verification

- ✅ `swift build`
- ✅ `testDatabaseReopenAfterAutoCheckpoint` (3-session multi-cycle reopen)
- ✅ `testRecoveryFromCorruptWAL` (5-session SIGKILL simulation)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author