### PR TITLE
ci: add concurrency, timeouts, and caching

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,9 +4,15 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ios-simulator-test:
     name: Build and Test on iOS Simulator
+    timeout-minutes: 30
     runs-on: macos-15
     strategy:
       matrix:
@@ -18,6 +24,21 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+      - uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-deriveddata-${{ matrix.config }}-${{ hashFiles('Sources/**', 'Package.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-deriveddata-${{ matrix.config }}-
+            ${{ runner.os }}-deriveddata-
       - name: Build for iOS Simulator
         run: |
           xcodebuild build-for-testing \
@@ -40,9 +61,18 @@ jobs:
 
   example:
     name: Build and Run Example
+    timeout-minutes: 15
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - name: Build example project
         working-directory: Example
         run: |


### PR DESCRIPTION
Modernize CI workflow:

- **Concurrency group** — new push cancels stale runs on same branch/PR
- **Timeouts** — 30 min for iOS Simulator tests, 15 min for Example
- **SPM cache** — both jobs cache `~/Library/Caches/org.swift.swiftpm` + `.build`
- **DerivedData cache** — iOS Simulator job caches Xcode DerivedData, keyed by config + source hash

Expected improvement: ~15-20 min faster on cache hits (C++ compilation is expensive).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author