### PR TITLE
fix: PreparedStatement reuse double-free crash

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -95,6 +95,12 @@ public final class Connection: @unchecked Sendable {
         _ preparedStatement: PreparedStatement,
         _ parameters: [String: T?]
     ) throws -> QueryResult {
+        // Invalidate the previous QueryResult from this PreparedStatement to prevent
+        // double-free. The C++ QueryResult may share internal state with the
+        // PreparedStatement; re-executing without destroying the old result first
+        // can cause the old result's deinit to free already-freed memory.
+        preparedStatement.activeQueryResult?.invalidate()
+
         var cQueryResult = kuzu_query_result()
         for (key, value) in parameters {
             let cValue = try swiftValueToKuzuValue(value)
@@ -134,6 +140,7 @@ public final class Connection: @unchecked Sendable {
             }
         }
         let queryResult = QueryResult(self, cQueryResult)
+        preparedStatement.activeQueryResult = queryResult
         return queryResult
     }
 

--- a/Sources/Kuzu/PreparedStatement.swift
+++ b/Sources/Kuzu/PreparedStatement.swift
@@ -13,6 +13,10 @@
 public final class PreparedStatement: @unchecked Sendable {
     internal var cPreparedStatement: kuzu_prepared_statement
     internal var connection: Connection
+    /// Weak reference to the most recent QueryResult produced by executing this statement.
+    /// Used to invalidate the previous result before re-execution, preventing double-free
+    /// when ARC defers deallocation of old results.
+    internal weak var activeQueryResult: QueryResult?
 
     /// Initializes a new PreparedStatement instance.
     /// - Parameters:

--- a/Sources/Kuzu/QueryResult.swift
+++ b/Sources/Kuzu/QueryResult.swift
@@ -17,6 +17,10 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
     internal var cQueryResult: kuzu_query_result
     internal var connection: Connection
     internal var columnNames: [String]?
+    /// Tracks whether the underlying C query result has already been destroyed.
+    /// This prevents double-free when a PreparedStatement is re-executed and the
+    /// previous QueryResult's C memory is invalidated before ARC calls deinit.
+    internal private(set) var isDestroyed = false
 
     /// An iterator type for QueryResult that conforms to IteratorProtocol.
     public struct Iterator: IteratorProtocol {
@@ -49,8 +53,19 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
         self.connection = connection
     }
 
-    deinit {
+    /// Explicitly destroys the underlying C query result and marks this object as destroyed.
+    /// After calling this, the QueryResult should not be used for any further operations.
+    internal func invalidate() {
+        guard !isDestroyed else { return }
         kuzu_query_result_destroy(&cQueryResult)
+        cQueryResult._query_result = nil
+        isDestroyed = true
+    }
+
+    deinit {
+        if !isDestroyed {
+            kuzu_query_result_destroy(&cQueryResult)
+        }
     }
 
     /// Returns the string representation of the QueryResult.

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -157,4 +157,41 @@ final class ConnectionTests: XCTestCase {
             XCTFail("Unexpected error type")
         }
     }
+
+    /// Regression test for GitHub issue #25: PreparedStatement reuse causes double-free.
+    /// When a PreparedStatement is executed multiple times, the resulting QueryResult
+    /// objects must not share internal C++ memory. Previously, ARC-deferred deallocation
+    /// of old QueryResult objects would free memory that a new execution had already
+    /// invalidated, causing a malloc double-free crash.
+    func testPreparedStatementReuseNoDoubleFree() throws {
+        let conn = try Connection(db)
+
+        // Create a table to delete from
+        _ = try conn.query(
+            "CREATE NODE TABLE TestItem (id STRING, PRIMARY KEY (id));"
+        )
+        _ = try conn.query("CREATE (t:TestItem {id: 'item1'});")
+        _ = try conn.query("CREATE (t:TestItem {id: 'item2'});")
+        _ = try conn.query("CREATE (t:TestItem {id: 'item3'});")
+
+        // Prepare once, execute multiple times — this previously crashed
+        let stmt = try conn.prepare(
+            "MATCH (t:TestItem {id: $id}) DELETE t"
+        )
+
+        for itemId in ["item1", "item2", "item3"] {
+            NSLog("Executing DELETE for %@", itemId)
+            _ = try conn.execute(stmt, ["id": itemId] as [String: Any?])
+        }
+
+        // Verify all items were deleted
+        let result = try conn.query(
+            "MATCH (t:TestItem) RETURN COUNT(t);"
+        )
+        XCTAssertTrue(result.hasNext())
+        let tuple = try result.getNext()!
+        let count = try tuple.getValue(0) as! Int64
+        XCTAssertEqual(count, 0, "All TestItem nodes should be deleted")
+        NSLog("testPreparedStatementReuseNoDoubleFree passed — no crash")
+    }
 }


### PR DESCRIPTION
Fixes double-free crash when reusing a PreparedStatement multiple times.

Added invalidate() mechanism to QueryResult — previous result is invalidated before re-execution, preventing ARC from double-freeing shared C++ memory.

- QueryResult.invalidate() sets internal pointer to nil, skips destroy on deinit
- PreparedStatement tracks activeQueryResult (weak ref)
- Connection.execute() invalidates previous result before new execution
- Added regression test: testPreparedStatementReuseNoDoubleFree

Closes #25