### PR TITLE
fix: Eager QueryResult destruction to prevent double-free

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -11,6 +11,11 @@
 public final class Connection: @unchecked Sendable {
     internal var cConnection: kuzu_connection
     internal var database: Database
+    /// Tracks the most recent QueryResult produced by this connection.
+    /// Before producing a new result, the previous one is eagerly destroyed
+    /// to prevent double-free crashes caused by shared C++ internal state
+    /// (catalog snapshots, memory pools) between results from the same connection.
+    internal weak var lastQueryResult: QueryResult?
 
     /// Opens a connection to the specified database.
     /// - Parameter database: The database to connect to
@@ -35,6 +40,9 @@ public final class Connection: @unchecked Sendable {
     /// - Returns: A QueryResult containing the results of the query
     /// - Throws: KuzuError if query execution fails
     public func query(_ cypher: String) throws -> QueryResult {
+        // Eagerly destroy previous result to prevent double-free from shared C++ state
+        lastQueryResult?.close()
+
         var cQueryResult = kuzu_query_result()
         kuzu_connection_query(&cConnection, cypher, &cQueryResult)
         if !kuzu_query_result_is_success(&cQueryResult) {
@@ -54,6 +62,7 @@ public final class Connection: @unchecked Sendable {
             }
         }
         let queryResult = QueryResult(self, cQueryResult)
+        lastQueryResult = queryResult
         return queryResult
     }
 
@@ -95,11 +104,11 @@ public final class Connection: @unchecked Sendable {
         _ preparedStatement: PreparedStatement,
         _ parameters: [String: T?]
     ) throws -> QueryResult {
-        // Invalidate the previous QueryResult from this PreparedStatement to prevent
-        // double-free. The C++ QueryResult may share internal state with the
-        // PreparedStatement; re-executing without destroying the old result first
-        // can cause the old result's deinit to free already-freed memory.
-        preparedStatement.activeQueryResult?.invalidate()
+        // Eagerly destroy previous results to prevent double-free from shared C++ state.
+        // Must destroy both: (1) the connection-level last result (covers cross-statement
+        // sharing) and (2) the statement-level active result (covers same-statement reuse).
+        lastQueryResult?.close()
+        preparedStatement.activeQueryResult?.close()
 
         var cQueryResult = kuzu_query_result()
         for (key, value) in parameters {
@@ -141,6 +150,7 @@ public final class Connection: @unchecked Sendable {
         }
         let queryResult = QueryResult(self, cQueryResult)
         preparedStatement.activeQueryResult = queryResult
+        lastQueryResult = queryResult
         return queryResult
     }
 

--- a/Sources/Kuzu/QueryResult.swift
+++ b/Sources/Kuzu/QueryResult.swift
@@ -53,13 +53,24 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
         self.connection = connection
     }
 
-    /// Explicitly destroys the underlying C query result and marks this object as destroyed.
-    /// After calling this, the QueryResult should not be used for any further operations.
-    internal func invalidate() {
+    /// Eagerly destroys the underlying C query result, releasing C++ memory immediately
+    /// instead of waiting for ARC deallocation. This prevents double-free crashes when
+    /// multiple QueryResult objects from the same Connection share internal C++ state
+    /// (catalog snapshots, memory pools, etc.) and are batch-deallocated by ARC.
+    ///
+    /// After calling `close()`, the QueryResult should not be used for any further operations.
+    /// It is safe to call `close()` multiple times.
+    public func close() {
         guard !isDestroyed else { return }
         kuzu_query_result_destroy(&cQueryResult)
         cQueryResult._query_result = nil
         isDestroyed = true
+    }
+
+    /// Explicitly destroys the underlying C query result and marks this object as destroyed.
+    /// After calling this, the QueryResult should not be used for any further operations.
+    internal func invalidate() {
+        close()
     }
 
     deinit {

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -194,4 +194,118 @@ final class ConnectionTests: XCTestCase {
         XCTAssertEqual(count, 0, "All TestItem nodes should be deleted")
         NSLog("testPreparedStatementReuseNoDoubleFree passed — no crash")
     }
+
+    /// Regression test for GitHub issue #25 (second comment): interleaved PreparedStatements
+    /// from the same Connection cause double-free during ARC batch deallocation.
+    /// The crash happens when multiple DIFFERENT PreparedStatements produce QueryResults
+    /// in a loop — ARC defers cleanup until scope exit, and the C++ results share
+    /// internal Connection state (catalog snapshots, memory pools).
+    func testInterleavedPreparedStatementsNoDoubleFree() throws {
+        let conn = try Connection(db)
+
+        // Set up: node tables with edges (mimics the moveToTrash pattern from issue #25)
+        _ = try conn.query(
+            "CREATE NODE TABLE Image (id STRING, PRIMARY KEY (id));"
+        )
+        _ = try conn.query(
+            "CREATE NODE TABLE Collection (id STRING, PRIMARY KEY (id));"
+        )
+        _ = try conn.query(
+            "CREATE REL TABLE BELONGS_TO (FROM Image TO Collection);"
+        )
+
+        // Create images and collections
+        _ = try conn.query("CREATE (c:Collection {id: 'source'});")
+        _ = try conn.query("CREATE (c:Collection {id: 'trash'});")
+        for i in 1...5 {
+            _ = try conn.query("CREATE (i:Image {id: 'img\(i)'});")
+            _ = try conn.query(
+                "MATCH (i:Image {id: 'img\(i)'}), (c:Collection {id: 'source'}) CREATE (i)-[:BELONGS_TO]->(c);"
+            )
+        }
+
+        // This is the exact pattern from the issue: interleaved prepare+execute with
+        // different statements in the same loop, producing multiple QueryResults.
+        let removeStmt = try conn.prepare("""
+            MATCH (i:Image {id: $iid})-[b:BELONGS_TO]->(c:Collection {id: $cid})
+            DELETE b
+            """)
+
+        let checkStmt = try conn.prepare("""
+            MATCH (i:Image {id: $iid})-[b:BELONGS_TO]->(c:Collection {id: $cid})
+            RETURN count(b)
+            """)
+
+        let createStmt = try conn.prepare("""
+            MATCH (i:Image {id: $iid}), (c:Collection {id: $cid})
+            CREATE (i)-[:BELONGS_TO]->(c)
+            """)
+
+        for i in 1...5 {
+            let imageId = "img\(i)"
+
+            // 1. Delete edge from source
+            _ = try conn.execute(
+                removeStmt,
+                ["iid": imageId, "cid": "source"] as [String: Any?]
+            )
+
+            // 2. Check if already in trash
+            let checkResult = try conn.execute(
+                checkStmt,
+                ["iid": imageId, "cid": "trash"] as [String: Any?]
+            )
+            if checkResult.hasNext() {
+                let tuple = try checkResult.getNext()!
+                let count = try tuple.getValue(0) as! Int64
+                XCTAssertEqual(count, 0)
+            }
+
+            // 3. Create edge to trash
+            _ = try conn.execute(
+                createStmt,
+                ["iid": imageId, "cid": "trash"] as [String: Any?]
+            )
+        }
+
+        // Verify: all images should now belong to trash, not source
+        let result = try conn.query(
+            "MATCH (i:Image)-[:BELONGS_TO]->(c:Collection {id: 'trash'}) RETURN COUNT(i);"
+        )
+        XCTAssertTrue(result.hasNext())
+        let tuple = try result.getNext()!
+        let count = try tuple.getValue(0) as! Int64
+        XCTAssertEqual(count, 5, "All 5 images should be in trash")
+
+        let sourceResult = try conn.query(
+            "MATCH (i:Image)-[:BELONGS_TO]->(c:Collection {id: 'source'}) RETURN COUNT(i);"
+        )
+        XCTAssertTrue(sourceResult.hasNext())
+        let sourceTuple = try sourceResult.getNext()!
+        let sourceCount = try sourceTuple.getValue(0) as! Int64
+        XCTAssertEqual(sourceCount, 0, "No images should remain in source")
+
+        NSLog("testInterleavedPreparedStatementsNoDoubleFree passed — no crash")
+    }
+
+    /// Tests that QueryResult.close() can be called explicitly for eager cleanup.
+    func testQueryResultExplicitClose() throws {
+        let conn = try Connection(db)
+        let result = try conn.query("MATCH (a:person) RETURN a.fName LIMIT 1;")
+        XCTAssertTrue(result.hasNext())
+        _ = try result.getNext()
+
+        // Explicitly close — should not crash
+        result.close()
+
+        // Calling close again should be safe (idempotent)
+        result.close()
+
+        // The connection should still work after closing a result
+        let result2 = try conn.query("RETURN 42;")
+        XCTAssertTrue(result2.hasNext())
+        let tuple = try result2.getNext()!
+        let value = try tuple.getValue(0) as! Int64
+        XCTAssertEqual(value, 42)
+    }
 }


### PR DESCRIPTION
Fixes the remaining double-free crash from #25 — interleaved PreparedStatements in the same scope cause ARC batch deallocation of shared C++ memory.

**Root cause:** Multiple QueryResults from different PreparedStatements share internal Connection state. ARC deallocates them all at function exit → double-free.

**Fix:** Eager destruction of C++ kuzu_query_result instead of relying on ARC timing:
- Added public close() method for immediate C++ cleanup
- Connection tracks lastQueryResult (weak) and eagerly closes previous result before new execute/query
- deinit is safety net, not primary cleanup path

**Tests added:**
- testInterleavedPreparedStatementsNoDoubleFree (exact repro from #25)
- testQueryResultExplicitClose

Closes #25