### PR TITLE
fix: Thread-safe Connection.lastQueryResult access

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -6,11 +6,14 @@
 //  This code is licensed under MIT license (see LICENSE for details)
 
 @_implementationOnly import cxx_kuzu
+import Foundation
 
 /// Represents a connection to a Kuzu database.
 public final class Connection: @unchecked Sendable {
     internal var cConnection: kuzu_connection
     internal var database: Database
+    /// Protects access to `lastQueryResult` across concurrent query/execute calls.
+    private let resultLock = NSLock()
     /// Tracks the most recent QueryResult produced by this connection.
     /// Before producing a new result, the previous one is eagerly destroyed
     /// to prevent double-free crashes caused by shared C++ internal state
@@ -41,7 +44,9 @@ public final class Connection: @unchecked Sendable {
     /// - Throws: KuzuError if query execution fails
     public func query(_ cypher: String) throws -> QueryResult {
         // Eagerly destroy previous result to prevent double-free from shared C++ state
+        resultLock.lock()
         lastQueryResult?.close()
+        resultLock.unlock()
 
         var cQueryResult = kuzu_query_result()
         kuzu_connection_query(&cConnection, cypher, &cQueryResult)
@@ -62,7 +67,9 @@ public final class Connection: @unchecked Sendable {
             }
         }
         let queryResult = QueryResult(self, cQueryResult)
+        resultLock.lock()
         lastQueryResult = queryResult
+        resultLock.unlock()
         return queryResult
     }
 
@@ -107,7 +114,9 @@ public final class Connection: @unchecked Sendable {
         // Eagerly destroy previous results to prevent double-free from shared C++ state.
         // Must destroy both: (1) the connection-level last result (covers cross-statement
         // sharing) and (2) the statement-level active result (covers same-statement reuse).
+        resultLock.lock()
         lastQueryResult?.close()
+        resultLock.unlock()
         preparedStatement.activeQueryResult?.close()
 
         var cQueryResult = kuzu_query_result()
@@ -150,7 +159,9 @@ public final class Connection: @unchecked Sendable {
         }
         let queryResult = QueryResult(self, cQueryResult)
         preparedStatement.activeQueryResult = queryResult
+        resultLock.lock()
         lastQueryResult = queryResult
+        resultLock.unlock()
         return queryResult
     }
 

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -288,6 +288,60 @@ final class ConnectionTests: XCTestCase {
         NSLog("testInterleavedPreparedStatementsNoDoubleFree passed — no crash")
     }
 
+    /// Tests that concurrent query/execute calls on the same Connection do not crash
+    /// due to races on lastQueryResult (thread-safety of the NSLock guard).
+    func testConcurrentConnectionAccess() throws {
+        let conn = try Connection(db)
+
+        // Set up a small table for mixed read/write queries
+        _ = try conn.query(
+            "CREATE NODE TABLE ConcItem (id INT64, val STRING, PRIMARY KEY (id));"
+        )
+        for i in 0..<10 {
+            _ = try conn.query("CREATE (n:ConcItem {id: \(i), val: 'init'});")
+        }
+
+        let iterations = 50
+        let workers = 4
+        let expectation = XCTestExpectation(description: "All concurrent workers finish")
+        expectation.expectedFulfillmentCount = workers
+
+        let errors = NSLock()
+        var collectedErrors: [Error] = []
+
+        for workerIdx in 0..<workers {
+            DispatchQueue.global().async {
+                for i in 0..<iterations {
+                    do {
+                        if i % 2 == 0 {
+                            // Read query
+                            let result = try conn.query(
+                                "MATCH (n:ConcItem) RETURN COUNT(n);"
+                            )
+                            _ = result.hasNext()
+                        } else {
+                            // Write query
+                            _ = try conn.query(
+                                "MATCH (n:ConcItem {id: \(workerIdx)}) SET n.val = 'w\(workerIdx)_i\(i)';"
+                            )
+                        }
+                    } catch {
+                        errors.lock()
+                        collectedErrors.append(error)
+                        errors.unlock()
+                    }
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 60.0)
+        XCTAssertTrue(
+            collectedErrors.isEmpty,
+            "Concurrent access produced errors: \(collectedErrors)"
+        )
+    }
+
     /// Tests that QueryResult.close() can be called explicitly for eager cleanup.
     func testQueryResultExplicitClose() throws {
         let conn = try Connection(db)


### PR DESCRIPTION
Fixes race condition in Connection.swift where concurrent threads accessing the same Connection could double-free via lastQueryResult.

**Root cause:** PR #29 added lastQueryResult weak tracking without lock protection. Since Connection is @unchecked Sendable, concurrent access is expected.

**Fix:** Added NSLock around all lastQueryResult reads/writes in query() and execute().

**Test added:** testConcurrentConnectionAccess — 4 threads × 50 queries on single Connection.

Related: #25

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author