### PR TITLE
refactor: Remove lastQueryResult bandaid — QueryResult owns its data independently

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -6,11 +6,14 @@
 //  This code is licensed under MIT license (see LICENSE for details)
 
 @_implementationOnly import cxx_kuzu
+import Foundation
 
 /// Represents a connection to a Kuzu database.
 public final class Connection: @unchecked Sendable {
     internal var cConnection: kuzu_connection
     internal var database: Database
+    /// Protects access to `lastQueryResult` across concurrent query/execute calls.
+    private let resultLock = NSLock()
     /// Tracks the most recent QueryResult produced by this connection.
     /// Before producing a new result, the previous one is eagerly destroyed
     /// to prevent double-free crashes caused by shared C++ internal state
@@ -41,7 +44,9 @@ public final class Connection: @unchecked Sendable {
     /// - Throws: KuzuError if query execution fails
     public func query(_ cypher: String) throws -> QueryResult {
         // Eagerly destroy previous result to prevent double-free from shared C++ state
+        resultLock.lock()
         lastQueryResult?.close()
+        resultLock.unlock()
 
         var cQueryResult = kuzu_query_result()
         kuzu_connection_query(&cConnection, cypher, &cQueryResult)
@@ -62,7 +67,9 @@ public final class Connection: @unchecked Sendable {
             }
         }
         let queryResult = QueryResult(self, cQueryResult)
+        resultLock.lock()
         lastQueryResult = queryResult
+        resultLock.unlock()
         return queryResult
     }
 
@@ -107,7 +114,9 @@ public final class Connection: @unchecked Sendable {
         // Eagerly destroy previous results to prevent double-free from shared C++ state.
         // Must destroy both: (1) the connection-level last result (covers cross-statement
         // sharing) and (2) the statement-level active result (covers same-statement reuse).
+        resultLock.lock()
         lastQueryResult?.close()
+        resultLock.unlock()
         preparedStatement.activeQueryResult?.close()
 
         var cQueryResult = kuzu_query_result()
@@ -150,7 +159,9 @@ public final class Connection: @unchecked Sendable {
         }
         let queryResult = QueryResult(self, cQueryResult)
         preparedStatement.activeQueryResult = queryResult
+        resultLock.lock()
         lastQueryResult = queryResult
+        resultLock.unlock()
         return queryResult
     }
 

--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -11,6 +11,11 @@
 public final class Connection: @unchecked Sendable {
     internal var cConnection: kuzu_connection
     internal var database: Database
+    /// Tracks the most recent QueryResult produced by this connection.
+    /// Before producing a new result, the previous one is eagerly destroyed
+    /// to prevent double-free crashes caused by shared C++ internal state
+    /// (catalog snapshots, memory pools) between results from the same connection.
+    internal weak var lastQueryResult: QueryResult?
 
     /// Opens a connection to the specified database.
     /// - Parameter database: The database to connect to
@@ -35,6 +40,9 @@ public final class Connection: @unchecked Sendable {
     /// - Returns: A QueryResult containing the results of the query
     /// - Throws: KuzuError if query execution fails
     public func query(_ cypher: String) throws -> QueryResult {
+        // Eagerly destroy previous result to prevent double-free from shared C++ state
+        lastQueryResult?.close()
+
         var cQueryResult = kuzu_query_result()
         kuzu_connection_query(&cConnection, cypher, &cQueryResult)
         if !kuzu_query_result_is_success(&cQueryResult) {
@@ -54,6 +62,7 @@ public final class Connection: @unchecked Sendable {
             }
         }
         let queryResult = QueryResult(self, cQueryResult)
+        lastQueryResult = queryResult
         return queryResult
     }
 
@@ -95,11 +104,11 @@ public final class Connection: @unchecked Sendable {
         _ preparedStatement: PreparedStatement,
         _ parameters: [String: T?]
     ) throws -> QueryResult {
-        // Invalidate the previous QueryResult from this PreparedStatement to prevent
-        // double-free. The C++ QueryResult may share internal state with the
-        // PreparedStatement; re-executing without destroying the old result first
-        // can cause the old result's deinit to free already-freed memory.
-        preparedStatement.activeQueryResult?.invalidate()
+        // Eagerly destroy previous results to prevent double-free from shared C++ state.
+        // Must destroy both: (1) the connection-level last result (covers cross-statement
+        // sharing) and (2) the statement-level active result (covers same-statement reuse).
+        lastQueryResult?.close()
+        preparedStatement.activeQueryResult?.close()
 
         var cQueryResult = kuzu_query_result()
         for (key, value) in parameters {
@@ -141,6 +150,7 @@ public final class Connection: @unchecked Sendable {
         }
         let queryResult = QueryResult(self, cQueryResult)
         preparedStatement.activeQueryResult = queryResult
+        lastQueryResult = queryResult
         return queryResult
     }
 

--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -6,19 +6,11 @@
 //  This code is licensed under MIT license (see LICENSE for details)
 
 @_implementationOnly import cxx_kuzu
-import Foundation
 
 /// Represents a connection to a Kuzu database.
 public final class Connection: @unchecked Sendable {
     internal var cConnection: kuzu_connection
     internal var database: Database
-    /// Protects access to `lastQueryResult` across concurrent query/execute calls.
-    private let resultLock = NSLock()
-    /// Tracks the most recent QueryResult produced by this connection.
-    /// Before producing a new result, the previous one is eagerly destroyed
-    /// to prevent double-free crashes caused by shared C++ internal state
-    /// (catalog snapshots, memory pools) between results from the same connection.
-    internal weak var lastQueryResult: QueryResult?
 
     /// Opens a connection to the specified database.
     /// - Parameter database: The database to connect to
@@ -43,11 +35,6 @@ public final class Connection: @unchecked Sendable {
     /// - Returns: A QueryResult containing the results of the query
     /// - Throws: KuzuError if query execution fails
     public func query(_ cypher: String) throws -> QueryResult {
-        // Eagerly destroy previous result to prevent double-free from shared C++ state
-        resultLock.lock()
-        lastQueryResult?.close()
-        resultLock.unlock()
-
         var cQueryResult = kuzu_query_result()
         kuzu_connection_query(&cConnection, cypher, &cQueryResult)
         if !kuzu_query_result_is_success(&cQueryResult) {
@@ -66,11 +53,7 @@ public final class Connection: @unchecked Sendable {
                 throw KuzuError.queryExecutionFailed(errorMessage)
             }
         }
-        let queryResult = QueryResult(self, cQueryResult)
-        resultLock.lock()
-        lastQueryResult = queryResult
-        resultLock.unlock()
-        return queryResult
+        return QueryResult(self, cQueryResult)
     }
 
     /// Returns a prepared statement for the specified query string.
@@ -111,14 +94,6 @@ public final class Connection: @unchecked Sendable {
         _ preparedStatement: PreparedStatement,
         _ parameters: [String: T?]
     ) throws -> QueryResult {
-        // Eagerly destroy previous results to prevent double-free from shared C++ state.
-        // Must destroy both: (1) the connection-level last result (covers cross-statement
-        // sharing) and (2) the statement-level active result (covers same-statement reuse).
-        resultLock.lock()
-        lastQueryResult?.close()
-        resultLock.unlock()
-        preparedStatement.activeQueryResult?.close()
-
         var cQueryResult = kuzu_query_result()
         for (key, value) in parameters {
             let cValue = try swiftValueToKuzuValue(value)
@@ -157,12 +132,7 @@ public final class Connection: @unchecked Sendable {
                 throw KuzuError.queryExecutionFailed(errorMessage)
             }
         }
-        let queryResult = QueryResult(self, cQueryResult)
-        preparedStatement.activeQueryResult = queryResult
-        resultLock.lock()
-        lastQueryResult = queryResult
-        resultLock.unlock()
-        return queryResult
+        return QueryResult(self, cQueryResult)
     }
 
     /// Sets the maximum number of threads that can be used for executing a query in parallel.

--- a/Sources/Kuzu/PreparedStatement.swift
+++ b/Sources/Kuzu/PreparedStatement.swift
@@ -13,10 +13,6 @@
 public final class PreparedStatement: @unchecked Sendable {
     internal var cPreparedStatement: kuzu_prepared_statement
     internal var connection: Connection
-    /// Weak reference to the most recent QueryResult produced by executing this statement.
-    /// Used to invalidate the previous result before re-execution, preventing double-free
-    /// when ARC defers deallocation of old results.
-    internal weak var activeQueryResult: QueryResult?
 
     /// Initializes a new PreparedStatement instance.
     /// - Parameters:

--- a/Sources/Kuzu/QueryResult.swift
+++ b/Sources/Kuzu/QueryResult.swift
@@ -54,9 +54,7 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
     }
 
     /// Eagerly destroys the underlying C query result, releasing C++ memory immediately
-    /// instead of waiting for ARC deallocation. This prevents double-free crashes when
-    /// multiple QueryResult objects from the same Connection share internal C++ state
-    /// (catalog snapshots, memory pools, etc.) and are batch-deallocated by ARC.
+    /// instead of waiting for ARC deallocation.
     ///
     /// After calling `close()`, the QueryResult should not be used for any further operations.
     /// It is safe to call `close()` multiple times.

--- a/Sources/Kuzu/QueryResult.swift
+++ b/Sources/Kuzu/QueryResult.swift
@@ -53,13 +53,24 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
         self.connection = connection
     }
 
-    /// Explicitly destroys the underlying C query result and marks this object as destroyed.
-    /// After calling this, the QueryResult should not be used for any further operations.
-    internal func invalidate() {
+    /// Eagerly destroys the underlying C query result, releasing C++ memory immediately
+    /// instead of waiting for ARC deallocation. This prevents double-free crashes when
+    /// multiple QueryResult objects from the same Connection share internal C++ state
+    /// (catalog snapshots, memory pools, etc.) and are batch-deallocated by ARC.
+    ///
+    /// After calling `close()`, the QueryResult should not be used for any further operations.
+    /// It is safe to call `close()` multiple times.
+    public func close() {
         guard !isDestroyed else { return }
         kuzu_query_result_destroy(&cQueryResult)
         cQueryResult._query_result = nil
         isDestroyed = true
+    }
+
+    /// Explicitly destroys the underlying C query result and marks this object as destroyed.
+    /// After calling this, the QueryResult should not be used for any further operations.
+    internal func invalidate() {
+        close()
     }
 
     deinit {

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -196,10 +196,7 @@ final class ConnectionTests: XCTestCase {
     }
 
     /// Regression test for GitHub issue #25 (second comment): interleaved PreparedStatements
-    /// from the same Connection cause double-free during ARC batch deallocation.
-    /// The crash happens when multiple DIFFERENT PreparedStatements produce QueryResults
-    /// in a loop — ARC defers cleanup until scope exit, and the C++ results share
-    /// internal Connection state (catalog snapshots, memory pools).
+    /// from the same Connection. Each QueryResult is independent and owns its data.
     func testInterleavedPreparedStatementsNoDoubleFree() throws {
         let conn = try Connection(db)
 
@@ -288,8 +285,7 @@ final class ConnectionTests: XCTestCase {
         NSLog("testInterleavedPreparedStatementsNoDoubleFree passed — no crash")
     }
 
-    /// Tests that concurrent query/execute calls on the same Connection do not crash
-    /// due to races on lastQueryResult (thread-safety of the NSLock guard).
+    /// Tests that concurrent query/execute calls on the same Connection do not crash.
     func testConcurrentConnectionAccess() throws {
         let conn = try Connection(db)
 

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -194,4 +194,118 @@ final class ConnectionTests: XCTestCase {
         XCTAssertEqual(count, 0, "All TestItem nodes should be deleted")
         NSLog("testPreparedStatementReuseNoDoubleFree passed — no crash")
     }
+
+    /// Regression test for GitHub issue #25 (second comment): interleaved PreparedStatements
+    /// from the same Connection cause double-free during ARC batch deallocation.
+    /// The crash happens when multiple DIFFERENT PreparedStatements produce QueryResults
+    /// in a loop — ARC defers cleanup until scope exit, and the C++ results share
+    /// internal Connection state (catalog snapshots, memory pools).
+    func testInterleavedPreparedStatementsNoDoubleFree() throws {
+        let conn = try Connection(db)
+
+        // Set up: node tables with edges (mimics the moveToTrash pattern from issue #25)
+        _ = try conn.query(
+            "CREATE NODE TABLE Image (id STRING, PRIMARY KEY (id));"
+        )
+        _ = try conn.query(
+            "CREATE NODE TABLE Collection (id STRING, PRIMARY KEY (id));"
+        )
+        _ = try conn.query(
+            "CREATE REL TABLE BELONGS_TO (FROM Image TO Collection);"
+        )
+
+        // Create images and collections
+        _ = try conn.query("CREATE (c:Collection {id: 'source'});")
+        _ = try conn.query("CREATE (c:Collection {id: 'trash'});")
+        for i in 1...5 {
+            _ = try conn.query("CREATE (i:Image {id: 'img\(i)'});")
+            _ = try conn.query(
+                "MATCH (i:Image {id: 'img\(i)'}), (c:Collection {id: 'source'}) CREATE (i)-[:BELONGS_TO]->(c);"
+            )
+        }
+
+        // This is the exact pattern from the issue: interleaved prepare+execute with
+        // different statements in the same loop, producing multiple QueryResults.
+        let removeStmt = try conn.prepare("""
+            MATCH (i:Image {id: $iid})-[b:BELONGS_TO]->(c:Collection {id: $cid})
+            DELETE b
+            """)
+
+        let checkStmt = try conn.prepare("""
+            MATCH (i:Image {id: $iid})-[b:BELONGS_TO]->(c:Collection {id: $cid})
+            RETURN count(b)
+            """)
+
+        let createStmt = try conn.prepare("""
+            MATCH (i:Image {id: $iid}), (c:Collection {id: $cid})
+            CREATE (i)-[:BELONGS_TO]->(c)
+            """)
+
+        for i in 1...5 {
+            let imageId = "img\(i)"
+
+            // 1. Delete edge from source
+            _ = try conn.execute(
+                removeStmt,
+                ["iid": imageId, "cid": "source"] as [String: Any?]
+            )
+
+            // 2. Check if already in trash
+            let checkResult = try conn.execute(
+                checkStmt,
+                ["iid": imageId, "cid": "trash"] as [String: Any?]
+            )
+            if checkResult.hasNext() {
+                let tuple = try checkResult.getNext()!
+                let count = try tuple.getValue(0) as! Int64
+                XCTAssertEqual(count, 0)
+            }
+
+            // 3. Create edge to trash
+            _ = try conn.execute(
+                createStmt,
+                ["iid": imageId, "cid": "trash"] as [String: Any?]
+            )
+        }
+
+        // Verify: all images should now belong to trash, not source
+        let result = try conn.query(
+            "MATCH (i:Image)-[:BELONGS_TO]->(c:Collection {id: 'trash'}) RETURN COUNT(i);"
+        )
+        XCTAssertTrue(result.hasNext())
+        let tuple = try result.getNext()!
+        let count = try tuple.getValue(0) as! Int64
+        XCTAssertEqual(count, 5, "All 5 images should be in trash")
+
+        let sourceResult = try conn.query(
+            "MATCH (i:Image)-[:BELONGS_TO]->(c:Collection {id: 'source'}) RETURN COUNT(i);"
+        )
+        XCTAssertTrue(sourceResult.hasNext())
+        let sourceTuple = try sourceResult.getNext()!
+        let sourceCount = try sourceTuple.getValue(0) as! Int64
+        XCTAssertEqual(sourceCount, 0, "No images should remain in source")
+
+        NSLog("testInterleavedPreparedStatementsNoDoubleFree passed — no crash")
+    }
+
+    /// Tests that QueryResult.close() can be called explicitly for eager cleanup.
+    func testQueryResultExplicitClose() throws {
+        let conn = try Connection(db)
+        let result = try conn.query("MATCH (a:person) RETURN a.fName LIMIT 1;")
+        XCTAssertTrue(result.hasNext())
+        _ = try result.getNext()
+
+        // Explicitly close — should not crash
+        result.close()
+
+        // Calling close again should be safe (idempotent)
+        result.close()
+
+        // The connection should still work after closing a result
+        let result2 = try conn.query("RETURN 42;")
+        XCTAssertTrue(result2.hasNext())
+        let tuple = try result2.getNext()!
+        let value = try tuple.getValue(0) as! Int64
+        XCTAssertEqual(value, 42)
+    }
 }

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -288,6 +288,60 @@ final class ConnectionTests: XCTestCase {
         NSLog("testInterleavedPreparedStatementsNoDoubleFree passed — no crash")
     }
 
+    /// Tests that concurrent query/execute calls on the same Connection do not crash
+    /// due to races on lastQueryResult (thread-safety of the NSLock guard).
+    func testConcurrentConnectionAccess() throws {
+        let conn = try Connection(db)
+
+        // Set up a small table for mixed read/write queries
+        _ = try conn.query(
+            "CREATE NODE TABLE ConcItem (id INT64, val STRING, PRIMARY KEY (id));"
+        )
+        for i in 0..<10 {
+            _ = try conn.query("CREATE (n:ConcItem {id: \(i), val: 'init'});")
+        }
+
+        let iterations = 50
+        let workers = 4
+        let expectation = XCTestExpectation(description: "All concurrent workers finish")
+        expectation.expectedFulfillmentCount = workers
+
+        let errors = NSLock()
+        var collectedErrors: [Error] = []
+
+        for workerIdx in 0..<workers {
+            DispatchQueue.global().async {
+                for i in 0..<iterations {
+                    do {
+                        if i % 2 == 0 {
+                            // Read query
+                            let result = try conn.query(
+                                "MATCH (n:ConcItem) RETURN COUNT(n);"
+                            )
+                            _ = result.hasNext()
+                        } else {
+                            // Write query
+                            _ = try conn.query(
+                                "MATCH (n:ConcItem {id: \(workerIdx)}) SET n.val = 'w\(workerIdx)_i\(i)';"
+                            )
+                        }
+                    } catch {
+                        errors.lock()
+                        collectedErrors.append(error)
+                        errors.unlock()
+                    }
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 60.0)
+        XCTAssertTrue(
+            collectedErrors.isEmpty,
+            "Concurrent access produced errors: \(collectedErrors)"
+        )
+    }
+
     /// Tests that QueryResult.close() can be called explicitly for eager cleanup.
     func testQueryResultExplicitClose() throws {
         let conn = try Connection(db)


### PR DESCRIPTION
Removes the lastQueryResult + NSLock mechanism added in PR #29 and #30.

**Why:** Deep analysis showed C++ QueryResult already owns all its data independently (FactorizedTable, iterator, tuple, column info). The 'shared Connection state' theory was wrong. Each QueryResult is self-contained.

**Changes:**
- Removed lastQueryResult weak tracking from Connection
- Removed NSLock from Connection
- Removed activeQueryResult from PreparedStatement
- Kept QueryResult.close() for optional explicit cleanup
- Updated doc comments

120 tests passing including concurrent access.

Related: #25