### PR TITLE
fix: Remove @unchecked Sendable from PreparedStatement — not thread-safe

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -9,6 +9,9 @@
 import Foundation
 
 /// Represents a connection to a Kuzu database.
+///
+/// Connection is thread-safe. Multiple threads can call ``query(_:)`` and ``execute(_:_:)`` concurrently.
+/// Queries are serialized internally via C++ mutex — for true parallelism, use separate Connections.
 public final class Connection: @unchecked Sendable {
     internal var cConnection: kuzu_connection
     internal var database: Database

--- a/Sources/Kuzu/Database.swift
+++ b/Sources/Kuzu/Database.swift
@@ -10,6 +10,8 @@ import Foundation
 @_implementationOnly import cxx_kuzu
 
 /// A class representing a Kuzu database instance.
+///
+/// Database is thread-safe. Multiple Connections can be created from the same Database across threads.
 public final class Database: @unchecked Sendable {
     internal var cDatabase: kuzu_database
 

--- a/Sources/Kuzu/PreparedStatement.swift
+++ b/Sources/Kuzu/PreparedStatement.swift
@@ -10,7 +10,18 @@
 /// A class representing a prepared statement in Kuzu.
 /// PreparedStatement can be used to execute a query with parameters.
 /// It is returned by the `prepare` method of Connection.
-public final class PreparedStatement: @unchecked Sendable {
+///
+/// PreparedStatement is **NOT** thread-safe. Do not share instances across threads or async tasks.
+/// Create a separate PreparedStatement per thread, or use ``Connection/query(_:)`` for simple cases.
+///
+/// For concurrent access, create separate Connection + PreparedStatement pairs:
+/// ```swift
+/// // Each task gets its own connection and statement
+/// let conn = try Connection(db)
+/// let stmt = try conn.prepare("MATCH (n {id: $id}) RETURN n")
+/// let result = try conn.execute(stmt, ["id": myId])
+/// ```
+public final class PreparedStatement {
     internal var cPreparedStatement: kuzu_prepared_statement
     internal var connection: Connection
 

--- a/Sources/Kuzu/QueryResult.swift
+++ b/Sources/Kuzu/QueryResult.swift
@@ -11,6 +11,8 @@ import Foundation
 /// A class representing the result of a query, which can be used to iterate over the result set.
 /// QueryResult is returned by the `query` and `execute` methods of Connection.
 /// It conforms to `CustomStringConvertible` and `Sequence` protocols for easy string representation and iteration.
+///
+/// QueryResult is thread-safe. Each result owns its data independently.
 public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
     Sendable
 {


### PR DESCRIPTION
PreparedStatement's internal _bound_values (std::unordered_map) has no synchronization. Concurrent bind/execute causes EXC_BAD_ACCESS (hash table corruption).

Instead of adding a lock (bandaid), we remove the false thread-safety promise:

- Removed @unchecked Sendable from PreparedStatement
- Swift compiler now warns developers who try to share PreparedStatements across concurrency boundaries
- Added thread-safety doc comments to all public classes:
  - Database: thread-safe ✅
  - Connection: thread-safe ✅ (C++ mutex)
  - QueryResult: thread-safe ✅ (owns data independently)
  - PreparedStatement: NOT thread-safe ❌ (by design)

Related: #25