### PR TITLE
fix: Remove lastQueryResult regression from PR #32 merge conflict

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -6,7 +6,6 @@
 //  This code is licensed under MIT license (see LICENSE for details)
 
 @_implementationOnly import cxx_kuzu
-import Foundation
 
 /// Represents a connection to a Kuzu database.
 ///
@@ -15,13 +14,6 @@ import Foundation
 public final class Connection: @unchecked Sendable {
     internal var cConnection: kuzu_connection
     internal var database: Database
-    /// Protects access to `lastQueryResult` across concurrent query/execute calls.
-    private let resultLock = NSLock()
-    /// Tracks the most recent QueryResult produced by this connection.
-    /// Before producing a new result, the previous one is eagerly destroyed
-    /// to prevent double-free crashes caused by shared C++ internal state
-    /// (catalog snapshots, memory pools) between results from the same connection.
-    internal weak var lastQueryResult: QueryResult?
 
     /// Opens a connection to the specified database.
     /// - Parameter database: The database to connect to
@@ -46,11 +38,6 @@ public final class Connection: @unchecked Sendable {
     /// - Returns: A QueryResult containing the results of the query
     /// - Throws: KuzuError if query execution fails
     public func query(_ cypher: String) throws -> QueryResult {
-        // Eagerly destroy previous result to prevent double-free from shared C++ state
-        resultLock.lock()
-        lastQueryResult?.close()
-        resultLock.unlock()
-
         var cQueryResult = kuzu_query_result()
         kuzu_connection_query(&cConnection, cypher, &cQueryResult)
         if !kuzu_query_result_is_success(&cQueryResult) {


### PR DESCRIPTION
PR #31 removed lastQueryResult + NSLock from Connection.swift. PR #32's merge conflict resolution accidentally brought them back. This PR removes them again.

Changes:
- Removed lastQueryResult weak var
- Removed resultLock (NSLock)
- Removed import Foundation (no longer needed)
- 13 lines deleted, 120 tests pass