### PR TITLE
fix: Swift wrapper audit — use-after-free guard, dealloc consistency, typo, Sendable

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -75,12 +75,12 @@ public final class Connection: @unchecked Sendable {
                 kuzu_prepared_statement_destroy(&cPreparedStatement)
             }
             if cErrorMesage == nil {
-                throw KuzuError.prepareStatmentFailed(
+                throw KuzuError.prepareStatementFailed(
                     "Prepare statement failed with an unknown error."
                 )
             } else {
                 let errorMessage = String(cString: cErrorMesage!)
-                throw KuzuError.prepareStatmentFailed(errorMessage)
+                throw KuzuError.prepareStatementFailed(errorMessage)
             }
         }
         let preparedStatement = PreparedStatement(self, cPreparedStatement)

--- a/Sources/Kuzu/Database.swift
+++ b/Sources/Kuzu/Database.swift
@@ -18,9 +18,6 @@ public final class Database: @unchecked Sendable {
     /// The original buffer pool size configured at initialization, used to restore after pressure.
     private let originalBufferPoolSize: UInt64
 
-    /// The current memory pressure level.
-    private var currentPressureLevel: MemoryPressureLevel = .normal
-
     #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         /// Dispatch source that monitors OS memory pressure events.
         private var memoryPressureSource: DispatchSourceMemoryPressure?
@@ -69,7 +66,6 @@ public final class Database: @unchecked Sendable {
     /// - `.critical`: reduced to 50% of original size
     /// - `.emergency`: reduced to 25% of original size
     public func handleMemoryPressure(level: MemoryPressureLevel) {
-        currentPressureLevel = level
         let ratio: Double
         switch level {
         case .normal:

--- a/Sources/Kuzu/FlatTuple.swift
+++ b/Sources/Kuzu/FlatTuple.swift
@@ -5,7 +5,6 @@
 //  Copyright © 2023 - 2025 Kùzu Inc.
 //  This code is licensed under MIT license (see LICENSE for details)
 
-import Foundation
 @_implementationOnly import cxx_kuzu
 
 /// A class representing a row in the result set of a query.
@@ -13,6 +12,7 @@ import Foundation
 /// It conforms to `CustomStringConvertible` protocol for easy string representation.
 public final class FlatTuple: CustomStringConvertible, @unchecked Sendable {
     internal var cFlatTuple: kuzu_flat_tuple
+    // Strong reference intentional: keeps QueryResult alive while FlatTuple is in use
     internal var queryResult: QueryResult
 
     internal init(

--- a/Sources/Kuzu/QueryResult.swift
+++ b/Sources/Kuzu/QueryResult.swift
@@ -82,15 +82,17 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
     /// Returns the string representation of the QueryResult.
     /// The string representation contains the column names and the tuples in the result set.
     public var description: String {
+        guard !isDestroyed else { return "<closed QueryResult>" }
         let cString: UnsafeMutablePointer<CChar> = kuzu_query_result_to_string(
             &cQueryResult
         )
-        defer { free(UnsafeMutableRawPointer(mutating: cString)) }
+        defer { kuzu_destroy_string(cString) }
         return String(cString: cString)
     }
 
     /// Returns true if there is at least one more tuple in the result set.
     public func hasNext() -> Bool {
+        guard !isDestroyed else { return false }
         return kuzu_query_result_has_next(&cQueryResult)
     }
 
@@ -98,6 +100,7 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
     /// - Returns: The next tuple, or nil if there are no more tuples.
     /// - Throws: `KuzuError.getFlatTupleFailed` if retrieving the next tuple fails.
     public func getNext() throws -> FlatTuple? {
+        guard !isDestroyed else { return nil }
         if !self.hasNext() {
             return nil
         }
@@ -113,6 +116,7 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
 
     /// Returns true if not all query results are consumed when multiple query statements are executed.
     public func hasNextQueryResult() -> Bool {
+        guard !isDestroyed else { return false }
         return kuzu_query_result_has_next_query_result(&cQueryResult)
     }
 
@@ -120,6 +124,7 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
     /// - Returns: The next query result, or nil if there are no more results.
     /// - Throws: `KuzuError.getNextQueryResultFailed` if retrieving the next query result fails.
     public func getNextQueryResult() throws -> QueryResult? {
+        guard !isDestroyed else { return nil }
         if !self.hasNextQueryResult() {
             return nil
         }
@@ -139,6 +144,7 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
     /// Resets the iterator of the QueryResult. After calling this method, the `getNext`
     /// method can be called to iterate over the result set from the beginning.
     public func resetIterator() {
+        guard !isDestroyed else { return }
         kuzu_query_result_reset_iterator(&cQueryResult)
     }
 
@@ -147,6 +153,7 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
         if let columnNames = self.columnNames {
             return columnNames
         }
+        guard !isDestroyed else { return [] }
 
         let numColumns = self.getColumnCount()
         columnNames = []
@@ -162,16 +169,19 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
 
     /// Returns the number of columns in the QueryResult.
     public func getColumnCount() -> UInt64 {
+        guard !isDestroyed else { return 0 }
         return kuzu_query_result_get_num_columns(&cQueryResult)
     }
 
     /// Returns the number of rows in the QueryResult.
     public func getRowCount() -> UInt64 {
+        guard !isDestroyed else { return 0 }
         return kuzu_query_result_get_num_tuples(&cQueryResult)
     }
 
     /// Returns the compiling time of the query in milliseconds.
     public func getCompilingTime() -> Double {
+        guard !isDestroyed else { return 0 }
         var cQuerySummary = kuzu_query_summary()
         defer {
             kuzu_query_summary_destroy(&cQuerySummary)
@@ -182,6 +192,7 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
 
     /// Returns the execution time of the query in milliseconds.
     public func getExecutionTime() -> Double {
+        guard !isDestroyed else { return 0 }
         var cQuerySummary = kuzu_query_summary()
         defer {
             kuzu_query_summary_destroy(&cQuerySummary)

--- a/Sources/Kuzu/SystemConfig.swift
+++ b/Sources/Kuzu/SystemConfig.swift
@@ -104,7 +104,7 @@ public final class SystemConfig: @unchecked Sendable {
         cSystemConfig.enable_compression = enableCompression
         cSystemConfig.read_only = readOnly
         cSystemConfig.auto_checkpoint = autoCheckpoint
-        if checkpointThreshold > 0 {
+        if checkpointThreshold != UInt64.max {
             cSystemConfig.checkpoint_threshold = checkpointThreshold
         }
         if maxDBSize > 0 {

--- a/Sources/Kuzu/Types.swift
+++ b/Sources/Kuzu/Types.swift
@@ -14,7 +14,7 @@ public enum KuzuError: Error {
     /// Query execution failed with the given error message.
     case queryExecutionFailed(String)
     /// Statement preparation failed with the given error message.
-    case prepareStatmentFailed(String)
+    case prepareStatementFailed(String)
     /// Value conversion failed with the given error message.
     case valueConversionFailed(String)
     /// Failed to get a flat tuple with the given error message.
@@ -30,7 +30,7 @@ public enum KuzuError: Error {
         case .databaseInitializationFailed(let msg),
             .connectionInitializationFailed(let msg),
             .queryExecutionFailed(let msg),
-            .prepareStatmentFailed(let msg),
+            .prepareStatementFailed(let msg),
             .valueConversionFailed(let msg),
             .getFlatTupleFailed(let msg),
             .getNextQueryResultFailed(let msg),
@@ -42,7 +42,7 @@ public enum KuzuError: Error {
 
 /// Represents the internal ID of a node or relationship in Kuzu.
 /// It conforms to the Equatable protocol for easy comparison.
-public struct KuzuInternalId: Equatable {
+public struct KuzuInternalId: Equatable, Sendable {
     /// The table ID of the node or relationship.
     public let tableId: UInt64
     /// The offset within the table.


### PR DESCRIPTION
## Swift Wrapper Audit Fixes

### 🚨 Critical
1. **QueryResult use-after-free guards** — All public methods now check `isDestroyed` before calling C API, returning safe defaults (false/nil/0/empty) instead of crashing.
2. **Database `currentPressureLevel` removal** — Removed unused property that was written from dispatch queue but never read, eliminating a potential race condition.
3. **QueryResult.description dealloc fix** — Changed `free()` to `kuzu_destroy_string()` to match kuzu's allocator, consistent with FlatTuple.description.

### ⚠️ Improvements
4. **FlatTuple strong reference documented** — Added comment explaining the intentional strong reference from FlatTuple→QueryResult (not a retain cycle).
5. **Typo fix: `prepareStatmentFailed` → `prepareStatementFailed`** — Fixed in Types.swift (definition + switch) and Connection.swift (throw sites). Public API change.
6. **KuzuInternalId Sendable** — Added `Sendable` conformance to the struct (all properties are already `let` value types).
7. **checkpointThreshold default logic** — Changed `if checkpointThreshold > 0` to `if checkpointThreshold != UInt64.max` so the default value correctly means "don't override".
8. **Remove unnecessary `import Foundation`** — Removed from FlatTuple.swift where nothing from Foundation is used.

### Verification
All 120 tests pass (`swift test --skip StressTests --skip ScaleTests`).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author