### PR TITLE
feat: ValueVector valueBuffer → MemoryManager allocation

### DIFF
--- a/Sources/cxx-kuzu/kuzu/src/common/vector/auxiliary_buffer.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/common/vector/auxiliary_buffer.cpp
@@ -5,6 +5,7 @@
 #include "common/constants.h"
 #include "common/system_config.h"
 #include "common/vector/value_vector.h"
+#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
 namespace common {
@@ -53,9 +54,13 @@ void ListAuxiliaryBuffer::resize(uint64_t numValues) {
 }
 
 void ListAuxiliaryBuffer::resizeDataVector(ValueVector* dataVector) {
-    auto buffer = std::make_unique<uint8_t[]>(capacity * dataVector->getNumBytesPerValue());
-    memcpy(buffer.get(), dataVector->valueBuffer.get(), size * dataVector->getNumBytesPerValue());
+    const auto newSize = capacity * dataVector->getNumBytesPerValue();
+    const auto copySize = size * dataVector->getNumBytesPerValue();
+    auto buffer = std::make_unique<uint8_t[]>(newSize);
+    memcpy(buffer.get(), dataVector->valueBufferPtr_, copySize);
     dataVector->valueBuffer = std::move(buffer);
+    dataVector->mmBuffer_.reset();
+    dataVector->valueBufferPtr_ = dataVector->valueBuffer.get();
     dataVector->nullMask.resize(capacity);
     // If the dataVector is a struct vector, we need to resize its field vectors.
     if (dataVector->dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {

--- a/Sources/cxx-kuzu/kuzu/src/common/vector/auxiliary_buffer.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/common/vector/auxiliary_buffer.cpp
@@ -56,13 +56,20 @@ void ListAuxiliaryBuffer::resize(uint64_t numValues) {
 void ListAuxiliaryBuffer::resizeDataVector(ValueVector* dataVector) {
     const auto newSize = capacity * dataVector->getNumBytesPerValue();
     const auto copySize = size * dataVector->getNumBytesPerValue();
-    auto buffer = std::make_unique<uint8_t[]>(newSize);
-    memcpy(buffer.get(), dataVector->valueBufferPtr_, copySize);
-    dataVector->valueBuffer = std::move(buffer);
-    dataVector->mmBuffer_.reset();
-    dataVector->valueBufferPtr_ = dataVector->valueBuffer.get();
+    if (dataVector->memoryManager_) {
+        auto newBuffer = dataVector->memoryManager_->allocateBuffer(true /*initializeToZero*/, newSize);
+        memcpy(newBuffer->getData(), dataVector->valueBufferPtr_, copySize);
+        dataVector->mmBuffer_ = std::move(newBuffer);
+        dataVector->valueBuffer.reset();
+        dataVector->valueBufferPtr_ = dataVector->mmBuffer_->getData();
+    } else {
+        auto buffer = std::make_unique<uint8_t[]>(newSize);
+        memcpy(buffer.get(), dataVector->valueBufferPtr_, copySize);
+        dataVector->valueBuffer = std::move(buffer);
+        dataVector->mmBuffer_.reset();
+        dataVector->valueBufferPtr_ = dataVector->valueBuffer.get();
+    }
     dataVector->nullMask.resize(capacity);
-    // If the dataVector is a struct vector, we need to resize its field vectors.
     if (dataVector->dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {
         resizeStructDataVector(dataVector);
     }

--- a/Sources/cxx-kuzu/kuzu/src/common/vector/value_vector.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/common/vector/value_vector.cpp
@@ -370,14 +370,13 @@ uint32_t ValueVector::getDataTypeSize(const LogicalType& type) {
 void ValueVector::initializeValueBuffer() {
     const auto bufferSize =
         static_cast<uint64_t>(numBytesPerValue) * DEFAULT_VECTOR_CAPACITY;
-    // TODO(mm-budget): Once the buffer pool budget accounts for valueBuffer allocations
-    // separately (or the headroom is adjusted), switch to:
-    //   mmBuffer_ = memoryManager_->allocateBuffer(false, bufferSize);
-    //   valueBufferPtr_ = mmBuffer_->getData();
-    // For now, use untracked heap allocation to avoid competing with
-    // factorized-table / column-chunk allocations for budget headroom.
-    valueBuffer = std::make_unique<uint8_t[]>(bufferSize);
-    valueBufferPtr_ = valueBuffer.get();
+    if (memoryManager_) {
+        mmBuffer_ = memoryManager_->allocateBuffer(true /*initializeToZero*/, bufferSize);
+        valueBufferPtr_ = mmBuffer_->getData();
+    } else {
+        valueBuffer = std::make_unique<uint8_t[]>(bufferSize);
+        valueBufferPtr_ = valueBuffer.get();
+    }
     if (dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {
         // For struct valueVectors, each struct_entry_t stores its current position in the
         // valueVector.

--- a/Sources/cxx-kuzu/kuzu/src/common/vector/value_vector.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/common/vector/value_vector.cpp
@@ -10,13 +10,15 @@
 #include "common/types/value/nested.h"
 #include "common/types/value/value.h"
 #include "common/vector/auxiliary_buffer.h"
+#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
 namespace common {
 
 ValueVector::ValueVector(LogicalType dataType, storage::MemoryManager* memoryManager,
     std::shared_ptr<DataChunkState> dataChunkState)
-    : dataType{std::move(dataType)}, nullMask{DEFAULT_VECTOR_CAPACITY} {
+    : dataType{std::move(dataType)}, memoryManager_{memoryManager}, valueBufferPtr_{nullptr},
+      nullMask{DEFAULT_VECTOR_CAPACITY} {
     if (this->dataType.getLogicalTypeID() == LogicalTypeID::ANY) {
         // LCOV_EXCL_START
         // Alternatively we can assign a default type here but I don't think it's a good practice.
@@ -31,6 +33,8 @@ ValueVector::ValueVector(LogicalType dataType, storage::MemoryManager* memoryMan
         setState(dataChunkState);
     }
 }
+
+ValueVector::~ValueVector() = default;
 
 void ValueVector::setState(const std::shared_ptr<DataChunkState>& state_) {
     this->state = state_;
@@ -86,7 +90,7 @@ bool ValueVector::setNullFromBits(const uint64_t* srcNullEntries, uint64_t srcOf
 
 template<typename T>
 void ValueVector::setValue(uint32_t pos, T val) {
-    ((T*)valueBuffer.get())[pos] = val;
+    ((T*)valueBufferPtr_)[pos] = val;
 }
 
 void ValueVector::copyFromRowData(uint32_t pos, const uint8_t* rowData) {
@@ -163,7 +167,7 @@ void ValueVector::copyFromValue(uint64_t pos, const Value& value) {
         return;
     }
     setNull(pos, false);
-    auto dstValue = valueBuffer.get() + pos * numBytesPerValue;
+    auto dstValue = valueBufferPtr_ + pos * numBytesPerValue;
     switch (dataType.getPhysicalType()) {
     case PhysicalTypeID::INT64: {
         memcpy(dstValue, &value.val.int64Val, numBytesPerValue);
@@ -364,7 +368,16 @@ uint32_t ValueVector::getDataTypeSize(const LogicalType& type) {
 }
 
 void ValueVector::initializeValueBuffer() {
-    valueBuffer = std::make_unique<uint8_t[]>(numBytesPerValue * DEFAULT_VECTOR_CAPACITY);
+    const auto bufferSize =
+        static_cast<uint64_t>(numBytesPerValue) * DEFAULT_VECTOR_CAPACITY;
+    // TODO(mm-budget): Once the buffer pool budget accounts for valueBuffer allocations
+    // separately (or the headroom is adjusted), switch to:
+    //   mmBuffer_ = memoryManager_->allocateBuffer(false, bufferSize);
+    //   valueBufferPtr_ = mmBuffer_->getData();
+    // For now, use untracked heap allocation to avoid competing with
+    // factorized-table / column-chunk allocations for budget headroom.
+    valueBuffer = std::make_unique<uint8_t[]>(bufferSize);
+    valueBufferPtr_ = valueBuffer.get();
     if (dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {
         // For struct valueVectors, each struct_entry_t stores its current position in the
         // valueVector.

--- a/Sources/cxx-kuzu/kuzu/src/include/common/vector/value_vector.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/common/vector/value_vector.h
@@ -34,7 +34,7 @@ public:
     }
 
     DELETE_COPY_AND_MOVE(ValueVector);
-    ~ValueVector() = default;
+    ~ValueVector();
 
     template<typename T>
     std::optional<T> firstNonNull() const {
@@ -95,11 +95,11 @@ public:
     // TODO(Guodong): Rename this to getValueRef
     template<typename T>
     const T& getValue(uint32_t pos) const {
-        return ((T*)valueBuffer.get())[pos];
+        return ((T*)valueBufferPtr_)[pos];
     }
     template<typename T>
     T& getValue(uint32_t pos) {
-        return ((T*)valueBuffer.get())[pos];
+        return ((T*)valueBufferPtr_)[pos];
     }
     template<typename T>
     void setValue(uint32_t pos, T val);
@@ -116,7 +116,7 @@ public:
 
     std::unique_ptr<Value> getAsValue(uint64_t pos) const;
 
-    uint8_t* getData() const { return valueBuffer.get(); }
+    uint8_t* getData() const { return valueBufferPtr_; }
 
     offset_t readNodeOffset(uint32_t pos) const {
         KU_ASSERT(dataType.getLogicalTypeID() == LogicalTypeID::INTERNAL_ID);
@@ -146,7 +146,12 @@ public:
     std::shared_ptr<DataChunkState> state;
 
 private:
-    std::unique_ptr<uint8_t[]> valueBuffer;
+    // When memoryManager_ is available, valueBuffer is backed by a MemoryBuffer (budget-tracked).
+    // When memoryManager_ is nullptr, we fall back to a plain heap allocation.
+    storage::MemoryManager* memoryManager_;
+    std::unique_ptr<storage::MemoryBuffer> mmBuffer_;   // owns the MM allocation (may be nullptr)
+    std::unique_ptr<uint8_t[]> valueBuffer;              // owns the fallback allocation (may be nullptr)
+    uint8_t* valueBufferPtr_;                            // hot-path pointer (always valid after init)
     NullMask nullMask;
     uint32_t numBytesPerValue;
     std::unique_ptr<AuxiliaryBuffer> auxiliaryBuffer;

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -20,6 +20,7 @@ final class ConnectionTests: XCTestCase {
     }
 
     override func tearDown() {
+        db = nil
         deleteTestDatabaseDirectory(path)
         super.tearDown()
     }

--- a/Tests/kuzu-swiftTests/FlatTupleTests.swift
+++ b/Tests/kuzu-swiftTests/FlatTupleTests.swift
@@ -21,6 +21,8 @@ final class FlatTupleTests: XCTestCase {
     }
 
     override func tearDown() {
+        conn = nil
+        db = nil
         deleteTestDatabaseDirectory(path)
         super.tearDown()
     }

--- a/Tests/kuzu-swiftTests/ParameterTests.swift
+++ b/Tests/kuzu-swiftTests/ParameterTests.swift
@@ -21,6 +21,8 @@ final class ParameterTests: XCTestCase {
     }
 
     override func tearDown() {
+        conn = nil
+        db = nil
         deleteTestDatabaseDirectory(path)
         super.tearDown()
     }

--- a/Tests/kuzu-swiftTests/QueryResultTests.swift
+++ b/Tests/kuzu-swiftTests/QueryResultTests.swift
@@ -21,6 +21,8 @@ final class QueryResultTests: XCTestCase {
     }
 
     override func tearDown() {
+        conn = nil
+        db = nil
         deleteTestDatabaseDirectory(path)
         super.tearDown()
     }

--- a/Tests/kuzu-swiftTests/ValueTests.swift
+++ b/Tests/kuzu-swiftTests/ValueTests.swift
@@ -21,6 +21,8 @@ final class ValueTests: XCTestCase {
     }
 
     override func tearDown() {
+        conn = nil
+        db = nil
         deleteTestDatabaseDirectory(path)
         super.tearDown()
     }


### PR DESCRIPTION
## Summary

Completes the ValueVector → MemoryManager allocation migration. ValueVector's `initializeValueBuffer()` and `ListAuxiliaryBuffer::resizeDataVector()` now use `MemoryManager::allocateBuffer()` when a MemoryManager is available, enabling proper budget tracking through the buffer pool's unified memory accounting.

### Phase 1 (previous commit)
- Added `memoryManager_`, `mmBuffer_`, `valueBufferPtr_` infrastructure to ValueVector
- Updated `getData()`, `getValue()`, `setValue()` to use `valueBufferPtr_`
- Left TODO for actual MM allocation

### Phase 2 (this commit)
- **`value_vector.cpp` — `initializeValueBuffer()`**: Removed TODO and implemented actual MemoryManager allocation with `allocateBuffer(true, bufferSize)`. Zero-initialization is critical — matches `make_unique<uint8_t[]>` behavior that downstream code depends on.
- **`auxiliary_buffer.cpp` — `resizeDataVector()`**: Uses MemoryManager allocation during list vector resizing when available.
- **Test tearDown**: Added explicit `conn = nil` / `db = nil` to ensure deterministic Database deallocation between test runs.

### Key Technical Detail

Using `initializeToZero=true` was the critical fix. The previous heap path (`make_unique<uint8_t[]>`) value-initializes buffers to zero, while `malloc` leaves memory uninitialized. Uninitialized ValueVector buffers caused memory corruption in downstream components.

### Testing

- All 120 tests pass (`swift test --skip StressTests --skip ScaleTests`)
- No buffer pool size changes needed — 256MB test budget is sufficient

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author