### PR TITLE
feat: Add HNSW vector index convenience API

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -282,4 +282,113 @@ public final class Connection: @unchecked Sendable {
         }
         return names
     }
+
+    // MARK: - HNSW Vector Index
+
+    /// Creates an HNSW vector index on an embedding column.
+    /// - Parameters:
+    ///   - table: Node table name (e.g., "Image").
+    ///   - indexName: Name for the index (e.g., "emb_idx").
+    ///   - property: Embedding column name (e.g., "embedding").
+    ///   - metric: Distance metric — "cosine", "l2", or "dotproduct" (default: "cosine").
+    /// - Throws: KuzuError if index creation fails.
+    public func createVectorIndex(
+        table: String,
+        indexName: String,
+        property: String,
+        metric: String = "cosine"
+    ) throws {
+        let result = try query(
+            "CALL CREATE_VECTOR_INDEX('\(table)', '\(indexName)', '\(property)', metric := '\(metric)')"
+        )
+        result.close()
+    }
+
+    /// Creates a vector index if one doesn't already exist. Safe to call on every app launch.
+    /// - Parameters:
+    ///   - table: Node table name.
+    ///   - indexName: Name for the index.
+    ///   - property: Embedding column name.
+    ///   - metric: Distance metric — "cosine", "l2", or "dotproduct" (default: "cosine").
+    /// - Returns: `true` if the index was created, `false` if it already existed.
+    /// - Throws: KuzuError if index creation fails for reasons other than the index already existing.
+    @discardableResult
+    public func createVectorIndexIfNotExists(
+        table: String,
+        indexName: String,
+        property: String,
+        metric: String = "cosine"
+    ) throws -> Bool {
+        do {
+            try createVectorIndex(table: table, indexName: indexName, property: property, metric: metric)
+            return true
+        } catch {
+            let msg = "\(error)"
+            if msg.contains("already exists") {
+                return false
+            }
+            throw error
+        }
+    }
+
+    /// Searches for K nearest neighbors using an HNSW vector index.
+    /// - Parameters:
+    ///   - table: Node table name.
+    ///   - indexName: Index name.
+    ///   - queryVector: The query embedding as a `[Float]` array.
+    ///   - k: Number of nearest neighbors to return.
+    ///   - filter: Optional Cypher filter (e.g., `"WHERE nn.collection_id = 5"`).
+    /// - Returns: Array of ``VectorSearchResult`` sorted by distance ascending.
+    /// - Throws: KuzuError if the query fails.
+    public func searchNearest(
+        table: String,
+        indexName: String,
+        queryVector: [Float],
+        k: Int,
+        filter: String? = nil
+    ) throws -> [VectorSearchResult] {
+        let vectorStr = "[" + queryVector.map { String($0) }.joined(separator: ",") + "]"
+
+        var cypher: String
+        if let filter = filter {
+            cypher = "CALL QUERY_VECTOR_INDEX('\(table)', '\(indexName)', CAST(\(vectorStr) AS FLOAT[\(queryVector.count)]), \(k), filter_statement := '\(filter)') YIELD node, distance RETURN node, distance ORDER BY distance ASC"
+        } else {
+            cypher = "CALL QUERY_VECTOR_INDEX('\(table)', '\(indexName)', CAST(\(vectorStr) AS FLOAT[\(queryVector.count)]), \(k)) YIELD node, distance RETURN node, distance ORDER BY distance ASC"
+        }
+
+        let result = try query(cypher)
+        defer { result.close() }
+
+        var results: [VectorSearchResult] = []
+        while result.hasNext() {
+            if let tuple = try result.getNext() {
+                // QUERY_VECTOR_INDEX yields node as a NODE and distance as DOUBLE
+                let distance = try tuple.getValue(1) as? Double ?? 0.0
+                if let node = try tuple.getValue(0) as? KuzuNode {
+                    results.append(VectorSearchResult(nodeID: node.id, distance: distance))
+                } else if let nodeID = try tuple.getValue(0) as? KuzuInternalId {
+                    results.append(VectorSearchResult(nodeID: nodeID, distance: distance))
+                }
+            }
+        }
+        return results
+    }
+
+    /// Drops an HNSW vector index.
+    /// - Parameters:
+    ///   - table: Node table name.
+    ///   - indexName: Index name.
+    /// - Throws: KuzuError if dropping the index fails.
+    public func dropVectorIndex(table: String, indexName: String) throws {
+        let result = try query("CALL DROP_VECTOR_INDEX('\(table)', '\(indexName)')")
+        result.close()
+    }
+}
+
+/// Search result from a vector index KNN query.
+public struct VectorSearchResult {
+    /// The internal ID of the matched node.
+    public let nodeID: KuzuInternalId
+    /// The distance from the query vector (lower is closer).
+    public let distance: Double
 }

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -939,4 +939,74 @@ final class ConnectionTests: XCTestCase {
         try conn.dropHashIndex(table: "T3", property: "name")
         try conn.dropHashIndex(table: "T3", property: "email")
     }
+
+    // MARK: - HNSW Vector Index Tests
+
+    func testVectorIndexCreateAndSearch() throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        // Create table with 4-dim embedding (small for test)
+        _ = try conn.query(
+            "CREATE NODE TABLE Item(id INT64, name STRING, embedding FLOAT[4], PRIMARY KEY(id))"
+        )
+
+        // Insert nodes with embeddings
+        _ = try conn.query("CREATE (:Item {id: 1, name: 'apple', embedding: [1.0, 0.0, 0.0, 0.0]})")
+        _ = try conn.query("CREATE (:Item {id: 2, name: 'banana', embedding: [0.9, 0.1, 0.0, 0.0]})")
+        _ = try conn.query("CREATE (:Item {id: 3, name: 'cherry', embedding: [0.0, 0.0, 1.0, 0.0]})")
+        _ = try conn.query("CREATE (:Item {id: 4, name: 'date', embedding: [0.0, 0.0, 0.9, 0.1]})")
+        _ = try conn.query("CREATE (:Item {id: 5, name: 'elderberry', embedding: [0.5, 0.5, 0.0, 0.0]})")
+
+        // Create vector index
+        try conn.createVectorIndex(table: "Item", indexName: "item_emb", property: "embedding", metric: "l2")
+
+        // Search nearest to [1.0, 0.0, 0.0, 0.0] — should find apple first, then banana
+        let results = try conn.searchNearest(
+            table: "Item", indexName: "item_emb", queryVector: [1.0, 0.0, 0.0, 0.0], k: 3
+        )
+        XCTAssertEqual(results.count, 3)
+        // Results should be sorted by distance ascending
+        XCTAssertTrue(results[0].distance <= results[1].distance)
+        XCTAssertTrue(results[1].distance <= results[2].distance)
+
+        // Drop index
+        try conn.dropVectorIndex(table: "Item", indexName: "item_emb")
+    }
+
+    func testVectorIndexIfNotExists() throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        _ = try conn.query(
+            "CREATE NODE TABLE V(id INT64, emb FLOAT[4], PRIMARY KEY(id))"
+        )
+        _ = try conn.query("CREATE (:V {id: 1, emb: [1.0, 0.0, 0.0, 0.0]})")
+
+        let created = try conn.createVectorIndexIfNotExists(
+            table: "V", indexName: "idx", property: "emb"
+        )
+        XCTAssertTrue(created)
+
+        let createdAgain = try conn.createVectorIndexIfNotExists(
+            table: "V", indexName: "idx", property: "emb"
+        )
+        XCTAssertFalse(createdAgain)
+    }
 }


### PR DESCRIPTION
## Summary

Adds Swift convenience methods for HNSW vector index operations on `Connection`.

### New API

- **`createVectorIndex(table:indexName:property:metric:)`** — Creates an HNSW vector index on an embedding column with configurable distance metric (cosine, l2, dotproduct)
- **`createVectorIndexIfNotExists(table:indexName:property:metric:)`** — Idempotent variant, safe to call on every app launch
- **`searchNearest(table:indexName:queryVector:k:filter:)`** — KNN search returning `[VectorSearchResult]` sorted by distance ascending, with optional Cypher filter support
- **`dropVectorIndex(table:indexName:)`** — Drops a vector index
- **`VectorSearchResult`** — Result struct with `nodeID: KuzuInternalId` and `distance: Double`

### Tests

- `testVectorIndexCreateAndSearch` — End-to-end: create table with embeddings, create index, search nearest neighbors, verify ordering, drop index
- `testVectorIndexIfNotExists` — Verifies idempotent creation returns correct boolean

All 135 tests pass (skipping stress/scale).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author