### PR TITLE
feat: Composite hash index for multi-property lookups

### DIFF
--- a/Sources/Kuzu/Connection.swift
+++ b/Sources/Kuzu/Connection.swift
@@ -283,6 +283,64 @@ public final class Connection: @unchecked Sendable {
         return names
     }
 
+    // MARK: - Composite Hash Index
+
+    /// Creates a composite hash index on multiple properties.
+    /// - Parameters:
+    ///   - table: The name of the node table.
+    ///   - properties: The names of the properties to include in the composite index.
+    /// - Throws: KuzuError if index creation fails.
+    public func createCompositeIndex(table: String, properties: [String]) throws {
+        let propStr = properties.joined(separator: ",")
+        let result = try query("CALL CREATE_HASH_INDEX('\(table)', '\(propStr)')")
+        result.close()
+    }
+
+    /// Creates a composite hash index if one doesn't already exist.
+    /// Safe to call on every app launch — idempotent.
+    /// - Parameters:
+    ///   - table: The name of the node table.
+    ///   - properties: The names of the properties to include in the composite index.
+    /// - Returns: `true` if the index was created, `false` if it already existed.
+    /// - Throws: KuzuError if index creation fails for reasons other than the index already existing.
+    @discardableResult
+    public func createCompositeIndexIfNotExists(table: String, properties: [String]) throws -> Bool {
+        do {
+            try createCompositeIndex(table: table, properties: properties)
+            return true
+        } catch {
+            let msg = "\(error)"
+            if msg.contains("already exists") {
+                return false
+            }
+            throw error
+        }
+    }
+
+    /// Looks up node internal IDs by composite indexed property values.
+    /// - Parameters:
+    ///   - table: The name of the node table.
+    ///   - properties: The names of the indexed properties (in order).
+    ///   - values: The string values to look up (in order matching properties).
+    /// - Returns: An array of matching internal IDs.
+    /// - Throws: KuzuError if the lookup fails.
+    public func lookupByCompositeIndex(table: String, properties: [String], values: [String]) throws -> [KuzuInternalId] {
+        let propStr = properties.joined(separator: ",")
+        let valStr = values.joined(separator: ",")
+        let result = try query("CALL QUERY_HASH_INDEX('\(table)', '\(propStr)', '\(valStr)') RETURN node_id")
+        defer { result.close() }
+        var ids: [KuzuInternalId] = []
+        while result.hasNext() {
+            if let tuple = try result.getNext() {
+                let val = try tuple.getValue(0)
+                if let id = val as? KuzuInternalId {
+                    ids.append(id)
+                }
+            }
+        }
+        return ids
+    }
+
     // MARK: - HNSW Vector Index
 
     /// Creates an HNSW vector index on an embedding column.

--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/function/create_hash_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/function/create_hash_index.cpp
@@ -25,10 +25,15 @@ namespace hash_index_extension {
 struct CreateHashIndexBindData final : TableFuncBindData {
     std::string tableName;
     table_id_t tableID;
-    std::string propertyName;
-    column_id_t columnID;
+    std::string propertyName;   // single property or comma-separated for composite
+    column_id_t columnID;       // single property column
     PhysicalTypeID keyType;
     LogicalType logicalType;
+    // Composite fields
+    bool isComposite = false;
+    std::vector<std::string> propertyNames;
+    std::vector<column_id_t> columnIDs;
+    std::vector<LogicalType> logicalTypes;
 
     CreateHashIndexBindData(std::string tableName, table_id_t tableID, std::string propertyName,
         column_id_t columnID, PhysicalTypeID keyType, LogicalType logicalType)
@@ -36,7 +41,26 @@ struct CreateHashIndexBindData final : TableFuncBindData {
           tableID{tableID}, propertyName{std::move(propertyName)}, columnID{columnID},
           keyType{keyType}, logicalType{std::move(logicalType)} {}
 
+    // Composite constructor
+    CreateHashIndexBindData(std::string tableName, table_id_t tableID,
+        std::string indexName,
+        std::vector<std::string> propertyNames,
+        std::vector<column_id_t> columnIDs,
+        std::vector<LogicalType> logicalTypes)
+        : TableFuncBindData{1 /* maxOffset */}, tableName{std::move(tableName)},
+          tableID{tableID}, propertyName{std::move(indexName)}, columnID{INVALID_COLUMN_ID},
+          keyType{PhysicalTypeID::STRING}, logicalType{LogicalType::STRING()},
+          isComposite{true}, propertyNames{std::move(propertyNames)},
+          columnIDs{std::move(columnIDs)}, logicalTypes{std::move(logicalTypes)} {}
+
     std::unique_ptr<TableFuncBindData> copy() const override {
+        if (isComposite) {
+            std::vector<LogicalType> ltCopy;
+            for (auto& lt : logicalTypes) ltCopy.push_back(lt.copy());
+            return std::make_unique<CreateHashIndexBindData>(
+                tableName, tableID, propertyName, propertyNames, columnIDs,
+                std::move(ltCopy));
+        }
         return std::make_unique<CreateHashIndexBindData>(
             tableName, tableID, propertyName, columnID, keyType, logicalType.copy());
     }
@@ -63,23 +87,69 @@ static void validateKeyType(PhysicalTypeID type) {
     }
 }
 
+// Helper to split comma-separated string and trim whitespace.
+static std::vector<std::string> splitProperties(const std::string& props) {
+    std::vector<std::string> result;
+    size_t start = 0;
+    for (size_t i = 0; i <= props.size(); i++) {
+        if (i == props.size() || props[i] == ',') {
+            auto part = props.substr(start, i - start);
+            // Trim whitespace
+            auto first = part.find_first_not_of(" \t");
+            auto last = part.find_last_not_of(" \t");
+            if (first != std::string::npos) {
+                result.push_back(part.substr(first, last - first + 1));
+            }
+            start = i + 1;
+        }
+    }
+    return result;
+}
+
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const TableFuncBindInput* input) {
     if (!context->getTransactionContext()->isAutoTransaction()) {
         throw BinderException("CREATE_HASH_INDEX is only supported in auto transaction mode.");
     }
     auto tableName = input->getLiteralVal<std::string>(0);
-    auto propertyName = input->getLiteralVal<std::string>(1);
+    auto propertyNameStr = input->getLiteralVal<std::string>(1);
     binder::Binder::validateTableExistence(*context, tableName);
     auto tableEntry =
         context->getCatalog()->getTableCatalogEntry(context->getTransaction(), tableName);
     binder::Binder::validateNodeTableType(tableEntry);
+
+    // Check if this is a composite index (comma-separated properties)
+    auto propNames = splitProperties(propertyNameStr);
+    if (propNames.size() > 1) {
+        // Composite index
+        std::vector<column_id_t> colIDs;
+        std::vector<LogicalType> logTypes;
+        for (auto& pn : propNames) {
+            binder::Binder::validateColumnExistence(tableEntry, pn);
+            colIDs.push_back(tableEntry->getColumnID(pn));
+            auto& propDef = tableEntry->getProperty(pn);
+            validateKeyType(propDef.getType().getPhysicalType());
+            logTypes.push_back(propDef.getType().copy());
+        }
+        // Index name is the comma-separated properties
+        auto indexName = propertyNameStr;
+        if (context->getCatalog()->containsIndex(
+                context->getTransaction(), tableEntry->getTableID(), indexName)) {
+            throw BinderException(stringFormat(
+                "Index {} already exists on table {}.", indexName, tableName));
+        }
+        return std::make_unique<CreateHashIndexBindData>(
+            tableName, tableEntry->getTableID(), indexName, propNames,
+            std::move(colIDs), std::move(logTypes));
+    }
+
+    // Single property index (original path)
+    auto& propertyName = propNames[0];
     binder::Binder::validateColumnExistence(tableEntry, propertyName);
     auto columnID = tableEntry->getColumnID(propertyName);
     auto& propDef = tableEntry->getProperty(propertyName);
     auto keyType = propDef.getType().getPhysicalType();
     validateKeyType(keyType);
-    // Check if index already exists
     auto indexName = propertyName;
     if (context->getCatalog()->containsIndex(
             context->getTransaction(), tableEntry->getTableID(), indexName)) {
@@ -101,58 +171,106 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto& nodeTable =
         storageManager->getTable(bindData.tableID)->cast<storage::NodeTable>();
 
-    // Build IndexInfo
     auto hashType = SecondaryHashIndex::getIndexType();
-    storage::IndexInfo indexInfo{bindData.propertyName, hashType.typeName, bindData.tableID,
-        {bindData.columnID}, {bindData.keyType},
-        hashType.constraintType == storage::IndexConstraintType::PRIMARY,
-        hashType.definitionType == storage::IndexDefinitionType::BUILTIN};
 
-    // Create storage info and index
-    auto storageInfo = std::make_unique<SecondaryHashIndexStorageInfo>(0, bindData.columnID);
-    auto index = std::make_unique<SecondaryHashIndex>(std::move(indexInfo), std::move(storageInfo));
+    if (bindData.isComposite) {
+        // === Composite index path ===
+        // For composite, always use STRING type (composite key is a concatenated string)
+        std::vector<PhysicalTypeID> keyTypes{PhysicalTypeID::STRING};
+        storage::IndexInfo indexInfo{bindData.propertyName, hashType.typeName, bindData.tableID,
+            bindData.columnIDs, keyTypes,
+            hashType.constraintType == storage::IndexConstraintType::PRIMARY,
+            hashType.definitionType == storage::IndexDefinitionType::BUILTIN};
 
-    // Scan existing data and populate index
-    auto numNodeGroups = nodeTable.getNumCommittedNodeGroups();
-    if (numNodeGroups > 0) {
-        // Construct data chunk with property column
-        std::vector<LogicalType> types;
-        types.push_back(bindData.logicalType.copy());
-        auto dataChunk = storage::Table::constructDataChunk(
-            clientContext->getMemoryManager(), std::move(types));
-        auto* propVector = &dataChunk.getValueVectorMutable(0);
-        auto nodeIDVector =
-            std::make_unique<ValueVector>(LogicalType::INTERNAL_ID(), clientContext->getMemoryManager());
-        nodeIDVector->setState(dataChunk.state);
+        auto storageInfoPtr = std::make_unique<SecondaryHashIndexStorageInfo>(
+            0, bindData.columnIDs, bindData.propertyNames);
+        auto index = std::make_unique<SecondaryHashIndex>(
+            std::move(indexInfo), std::move(storageInfoPtr));
 
-        std::vector<ValueVector*> outVectors{propVector};
-        auto scanState = std::make_unique<storage::NodeTableScanState>(
-            nodeIDVector.get(), outVectors, dataChunk.state);
-        scanState->setToTable(transaction, &nodeTable, {bindData.columnID}, {});
+        // Scan existing data
+        auto numNodeGroups = nodeTable.getNumCommittedNodeGroups();
+        if (numNodeGroups > 0) {
+            std::vector<LogicalType> types;
+            for (auto& lt : bindData.logicalTypes) types.push_back(lt.copy());
+            auto dataChunk = storage::Table::constructDataChunk(
+                clientContext->getMemoryManager(), std::move(types));
+            std::vector<ValueVector*> outVectors;
+            for (uint32_t c = 0; c < bindData.columnIDs.size(); c++) {
+                outVectors.push_back(&dataChunk.getValueVectorMutable(c));
+            }
+            auto nodeIDVector = std::make_unique<ValueVector>(
+                LogicalType::INTERNAL_ID(), clientContext->getMemoryManager());
+            nodeIDVector->setState(dataChunk.state);
 
-        auto insertState = index->initInsertState(clientContext, nullptr);
+            auto scanState = std::make_unique<storage::NodeTableScanState>(
+                nodeIDVector.get(), outVectors, dataChunk.state);
+            scanState->setToTable(transaction, &nodeTable, bindData.columnIDs, {});
 
-        for (node_group_idx_t ng = 0; ng < numNodeGroups; ng++) {
-            scanState->source = storage::TableScanSource::COMMITTED;
-            scanState->nodeGroupIdx = ng;
-            nodeTable.initScanState(transaction, *scanState);
-            while (nodeTable.scan(transaction, *scanState)) {
-                auto selSize = dataChunk.state->getSelSize();
-                if (selSize == 0) continue;
-                std::vector<ValueVector*> indexVectors{propVector};
-                index->insert(transaction, *nodeIDVector, indexVectors, *insertState);
+            auto insertState = index->initInsertState(clientContext, nullptr);
+
+            for (node_group_idx_t ng = 0; ng < numNodeGroups; ng++) {
+                scanState->source = storage::TableScanSource::COMMITTED;
+                scanState->nodeGroupIdx = ng;
+                nodeTable.initScanState(transaction, *scanState);
+                while (nodeTable.scan(transaction, *scanState)) {
+                    if (dataChunk.state->getSelSize() == 0) continue;
+                    index->insert(transaction, *nodeIDVector, outVectors, *insertState);
+                }
             }
         }
+
+        auto indexEntry = std::make_unique<IndexCatalogEntry>(
+            hashType.typeName, bindData.tableID, bindData.propertyName,
+            std::vector<property_id_t>{}, std::make_unique<HashIndexAuxInfo>());
+        catalog->createIndex(transaction, std::move(indexEntry));
+        nodeTable.addIndex(std::move(index));
+    } else {
+        // === Single property index path (original) ===
+        storage::IndexInfo indexInfo{bindData.propertyName, hashType.typeName, bindData.tableID,
+            {bindData.columnID}, {bindData.keyType},
+            hashType.constraintType == storage::IndexConstraintType::PRIMARY,
+            hashType.definitionType == storage::IndexDefinitionType::BUILTIN};
+
+        auto storageInfoPtr = std::make_unique<SecondaryHashIndexStorageInfo>(0, bindData.columnID);
+        auto index = std::make_unique<SecondaryHashIndex>(
+            std::move(indexInfo), std::move(storageInfoPtr));
+
+        auto numNodeGroups = nodeTable.getNumCommittedNodeGroups();
+        if (numNodeGroups > 0) {
+            std::vector<LogicalType> types;
+            types.push_back(bindData.logicalType.copy());
+            auto dataChunk = storage::Table::constructDataChunk(
+                clientContext->getMemoryManager(), std::move(types));
+            auto* propVector = &dataChunk.getValueVectorMutable(0);
+            auto nodeIDVector = std::make_unique<ValueVector>(
+                LogicalType::INTERNAL_ID(), clientContext->getMemoryManager());
+            nodeIDVector->setState(dataChunk.state);
+
+            std::vector<ValueVector*> outVectors{propVector};
+            auto scanState = std::make_unique<storage::NodeTableScanState>(
+                nodeIDVector.get(), outVectors, dataChunk.state);
+            scanState->setToTable(transaction, &nodeTable, {bindData.columnID}, {});
+
+            auto insertState = index->initInsertState(clientContext, nullptr);
+
+            for (node_group_idx_t ng = 0; ng < numNodeGroups; ng++) {
+                scanState->source = storage::TableScanSource::COMMITTED;
+                scanState->nodeGroupIdx = ng;
+                nodeTable.initScanState(transaction, *scanState);
+                while (nodeTable.scan(transaction, *scanState)) {
+                    if (dataChunk.state->getSelSize() == 0) continue;
+                    std::vector<ValueVector*> indexVectors{propVector};
+                    index->insert(transaction, *nodeIDVector, indexVectors, *insertState);
+                }
+            }
+        }
+
+        auto indexEntry = std::make_unique<IndexCatalogEntry>(
+            hashType.typeName, bindData.tableID, bindData.propertyName,
+            std::vector<property_id_t>{}, std::make_unique<HashIndexAuxInfo>());
+        catalog->createIndex(transaction, std::move(indexEntry));
+        nodeTable.addIndex(std::move(index));
     }
-
-    // Register index in catalog
-    auto indexEntry = std::make_unique<IndexCatalogEntry>(
-        hashType.typeName, bindData.tableID, bindData.propertyName,
-        std::vector<property_id_t>{}, std::make_unique<HashIndexAuxInfo>());
-    catalog->createIndex(transaction, std::move(indexEntry));
-
-    // Add index to node table
-    nodeTable.addIndex(std::move(index));
 
     return 0;
 }

--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/function/query_hash_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/function/query_hash_index.cpp
@@ -51,7 +51,6 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         throw BinderException(
             stringFormat("Table {} doesn't have an index with name {}.", tableName, indexName));
     }
-    // Get the index and perform lookup
     auto storageManager = context->getStorageManager();
     auto& nodeTable =
         storageManager->getTable(tableID)->cast<storage::NodeTable>();
@@ -62,63 +61,77 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     }
     auto* index = &indexOpt.value()->cast<SecondaryHashIndex>();
 
-    // Get the lookup value and convert to key data
-    auto lookupValue = input->getLiteralVal<std::string>(2);
     std::vector<offset_t> resultOffsets;
 
-    // Perform lookup based on key type
-    auto keyType = index->getIndexInfo().keyDataTypes[0];
-    TypeUtils::visit(
-        keyType,
-        [&](ku_string_t) {
-            ku_string_t kuStr(lookupValue.data(), lookupValue.size());
-            index->lookup(reinterpret_cast<const uint8_t*>(&kuStr), resultOffsets);
-        },
-        [&](int64_t) {
-            auto val = std::stoll(lookupValue);
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](int32_t) {
-            auto val = static_cast<int32_t>(std::stoi(lookupValue));
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](int16_t) {
-            auto val = static_cast<int16_t>(std::stoi(lookupValue));
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](int8_t) {
-            auto val = static_cast<int8_t>(std::stoi(lookupValue));
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](uint64_t) {
-            auto val = std::stoull(lookupValue);
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](uint32_t) {
-            auto val = static_cast<uint32_t>(std::stoul(lookupValue));
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](uint16_t) {
-            auto val = static_cast<uint16_t>(std::stoul(lookupValue));
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](uint8_t) {
-            auto val = static_cast<uint8_t>(std::stoul(lookupValue));
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](double) {
-            auto val = std::stod(lookupValue);
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](float) {
-            auto val = std::stof(lookupValue);
-            index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
-        },
-        [&](auto) {
-            throw BinderException("Unsupported key type for hash index query.");
-        });
+    if (index->isComposite()) {
+        // Composite lookup: third param is comma-separated values
+        auto valuesStr = input->getLiteralVal<std::string>(2);
+        // Split values by comma
+        std::vector<std::string> values;
+        size_t start = 0;
+        for (size_t i = 0; i <= valuesStr.size(); i++) {
+            if (i == valuesStr.size() || valuesStr[i] == ',') {
+                values.push_back(valuesStr.substr(start, i - start));
+                start = i + 1;
+            }
+        }
+        auto compositeKey = SecondaryHashIndex::buildCompositeKey(values);
+        index->lookupComposite(compositeKey, resultOffsets);
+    } else {
+        // Single property lookup (original path)
+        auto lookupValue = input->getLiteralVal<std::string>(2);
+        auto keyType = index->getIndexInfo().keyDataTypes[0];
+        TypeUtils::visit(
+            keyType,
+            [&](ku_string_t) {
+                ku_string_t kuStr(lookupValue.data(), lookupValue.size());
+                index->lookup(reinterpret_cast<const uint8_t*>(&kuStr), resultOffsets);
+            },
+            [&](int64_t) {
+                auto val = std::stoll(lookupValue);
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](int32_t) {
+                auto val = static_cast<int32_t>(std::stoi(lookupValue));
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](int16_t) {
+                auto val = static_cast<int16_t>(std::stoi(lookupValue));
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](int8_t) {
+                auto val = static_cast<int8_t>(std::stoi(lookupValue));
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](uint64_t) {
+                auto val = std::stoull(lookupValue);
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](uint32_t) {
+                auto val = static_cast<uint32_t>(std::stoul(lookupValue));
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](uint16_t) {
+                auto val = static_cast<uint16_t>(std::stoul(lookupValue));
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](uint8_t) {
+                auto val = static_cast<uint8_t>(std::stoul(lookupValue));
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](double) {
+                auto val = std::stod(lookupValue);
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](float) {
+                auto val = std::stof(lookupValue);
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
+            [&](auto) {
+                throw BinderException("Unsupported key type for hash index query.");
+            });
+    }
 
-    // Create output columns
     std::vector<std::string> columnNames = {"node_id"};
     std::vector<LogicalType> columnTypes;
     columnTypes.push_back(LogicalType::INTERNAL_ID());

--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/include/index/secondary_hash_index.h
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/include/index/secondary_hash_index.h
@@ -40,11 +40,20 @@ struct HashIndexAuxInfo final : catalog::IndexAuxInfo {
 struct SecondaryHashIndexStorageInfo final : storage::IndexStorageInfo {
     uint64_t numEntries = 0;
     common::column_id_t columnID = common::INVALID_COLUMN_ID;
+    std::vector<common::column_id_t> columnIDs; // for composite indexes
+    std::vector<std::string> propertyNames;      // for composite indexes
     std::vector<uint8_t> serializedData; // checkpoint entry data
 
     SecondaryHashIndexStorageInfo() = default;
     SecondaryHashIndexStorageInfo(uint64_t numEntries, common::column_id_t columnID)
         : numEntries{numEntries}, columnID{columnID} {}
+    SecondaryHashIndexStorageInfo(uint64_t numEntries,
+        std::vector<common::column_id_t> columnIDs,
+        std::vector<std::string> propertyNames)
+        : numEntries{numEntries}, columnID{columnIDs.empty() ? common::INVALID_COLUMN_ID : columnIDs[0]},
+          columnIDs{std::move(columnIDs)}, propertyNames{std::move(propertyNames)} {}
+
+    bool isComposite() const { return columnIDs.size() > 1; }
 
     std::shared_ptr<common::BufferWriter> serialize() const override;
     static std::unique_ptr<IndexStorageInfo> deserialize(
@@ -66,6 +75,8 @@ public:
     virtual void clear() = 0;
     virtual void serializeEntries(common::Serializer& serializer) const = 0;
     virtual void deserializeEntries(common::Deserializer& deserializer) = 0;
+    // Get the stored key as string for a given offset (used for composite update).
+    virtual std::string getKeyStringForOffset(common::offset_t nodeOffset) const = 0;
 };
 
 template<typename T>
@@ -86,6 +97,15 @@ public:
     }
     void serializeEntries(common::Serializer& serializer) const override;
     void deserializeEntries(common::Deserializer& deserializer) override;
+    std::string getKeyStringForOffset(common::offset_t nodeOffset) const override {
+        auto it = reverseMap.find(nodeOffset);
+        if (it == reverseMap.end()) return "";
+        if constexpr (std::is_same_v<KeyType, std::string>) {
+            return it->second;
+        } else {
+            return common::TypeUtils::toString(it->second);
+        }
+    }
 
 private:
     KeyType extractKey(const uint8_t* data) const;
@@ -138,6 +158,18 @@ public:
 
     // Public lookup API for query functions.
     bool lookup(const uint8_t* keyData, std::vector<common::offset_t>& result) const override;
+
+    // Composite key lookup by pre-built composite key string.
+    bool lookupComposite(const std::string& compositeKey,
+        std::vector<common::offset_t>& result) const;
+
+    // Build a composite key from individual string values using null-byte separator.
+    static std::string buildCompositeKey(const std::vector<std::string>& values);
+
+    // Split a composite key back into individual values.
+    static std::vector<std::string> splitCompositeKey(const std::string& compositeKey);
+
+    bool isComposite() const;
 
 private:
     void initInnerIndex();

--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/index/secondary_hash_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/index/secondary_hash_index.cpp
@@ -26,6 +26,17 @@ std::shared_ptr<BufferWriter> SecondaryHashIndexStorageInfo::serialize() const {
     if (dataSize > 0) {
         serializer.write(serializedData.data(), dataSize);
     }
+    // Write composite index data
+    uint64_t numCompositeColumns = columnIDs.size();
+    serializer.write<uint64_t>(numCompositeColumns);
+    for (auto cid : columnIDs) {
+        serializer.write<column_id_t>(cid);
+    }
+    uint64_t numPropNames = propertyNames.size();
+    serializer.write<uint64_t>(numPropNames);
+    for (auto& pn : propertyNames) {
+        serializer.write<std::string>(pn);
+    }
     return bufferWriter;
 }
 
@@ -44,6 +55,21 @@ std::unique_ptr<IndexStorageInfo> SecondaryHashIndexStorageInfo::deserialize(
         if (dataSize > 0) {
             si->serializedData.resize(dataSize);
             deSer.read(si->serializedData.data(), dataSize);
+        }
+    }
+    // Read composite index data if present
+    if (!deSer.finished()) {
+        uint64_t numCompositeColumns = 0;
+        deSer.deserializeValue<uint64_t>(numCompositeColumns);
+        si->columnIDs.resize(numCompositeColumns);
+        for (uint64_t i = 0; i < numCompositeColumns; i++) {
+            deSer.deserializeValue<column_id_t>(si->columnIDs[i]);
+        }
+        uint64_t numPropNames = 0;
+        deSer.deserializeValue<uint64_t>(numPropNames);
+        si->propertyNames.resize(numPropNames);
+        for (uint64_t i = 0; i < numPropNames; i++) {
+            deSer.deserializeValue<std::string>(si->propertyNames[i]);
         }
     }
     return si;
@@ -235,22 +261,48 @@ std::unique_ptr<Index::InsertState> SecondaryHashIndex::initInsertState(
     return std::make_unique<SecondaryInsertState>();
 }
 
+// Helper: extract a string representation from a ValueVector at given position.
+static std::string vectorValueToString(const ValueVector* vec, sel_t pos) {
+    return TypeUtils::entryToString(vec->dataType,
+        vec->getData() + vec->getNumBytesPerValue() * pos, const_cast<ValueVector*>(vec));
+}
+
 void SecondaryHashIndex::insert(transaction::Transaction* /*transaction*/,
     const ValueVector& nodeIDVector, const std::vector<ValueVector*>& indexVectors,
     InsertState& /*insertState*/) {
     KU_ASSERT(!indexVectors.empty());
-    auto* propVector = indexVectors[0];
+    auto& si = storageInfo->cast<SecondaryHashIndexStorageInfo>();
+    const bool composite = si.isComposite();
     std::lock_guard<std::mutex> lock(mtx);
     for (auto i = 0u; i < nodeIDVector.state->getSelSize(); i++) {
         auto pos = nodeIDVector.state->getSelVector()[i];
-        if (propVector->isNull(pos)) {
-            continue;
-        }
         auto nodeOffset = nodeIDVector.getValue<internalID_t>(pos).offset;
-        auto* keyData = propVector->getData() + propVector->getNumBytesPerValue() * pos;
-        innerIndex->insertEntry(keyData, nodeOffset);
+        if (composite) {
+            // Check if ANY property is null — skip entire row if so
+            bool hasNull = false;
+            for (auto* vec : indexVectors) {
+                if (vec->isNull(pos)) {
+                    hasNull = true;
+                    break;
+                }
+            }
+            if (hasNull) continue;
+            // Build composite key from all property vectors
+            std::vector<std::string> parts;
+            parts.reserve(indexVectors.size());
+            for (auto* vec : indexVectors) {
+                parts.push_back(vectorValueToString(vec, pos));
+            }
+            auto compositeKey = buildCompositeKey(parts);
+            ku_string_t kuStr(compositeKey.data(), compositeKey.size());
+            innerIndex->insertEntry(reinterpret_cast<const uint8_t*>(&kuStr), nodeOffset);
+        } else {
+            auto* propVector = indexVectors[0];
+            if (propVector->isNull(pos)) continue;
+            auto* keyData = propVector->getData() + propVector->getNumBytesPerValue() * pos;
+            innerIndex->insertEntry(keyData, nodeOffset);
+        }
     }
-    auto& si = storageInfo->cast<SecondaryHashIndexStorageInfo>();
     si.numEntries = innerIndex->size();
 }
 
@@ -261,20 +313,40 @@ std::unique_ptr<Index::UpdateState> SecondaryHashIndex::initUpdateState(
 
 void SecondaryHashIndex::update(transaction::Transaction* /*transaction*/,
     const ValueVector& nodeIDVector, ValueVector& propertyVector,
-    UpdateState& /*updateState*/) {
+    UpdateState& updateState) {
+    auto& si = storageInfo->cast<SecondaryHashIndexStorageInfo>();
+    auto& updState = updateState.cast<SecondaryUpdateState>();
     std::lock_guard<std::mutex> lock(mtx);
     for (auto i = 0u; i < nodeIDVector.state->getSelSize(); i++) {
         auto pos = nodeIDVector.state->getSelVector()[i];
         auto nodeOffset = nodeIDVector.getValue<internalID_t>(pos).offset;
-        // Delete old entry using reverse map
-        innerIndex->deleteByOffset(nodeOffset);
-        // Insert new entry
-        if (!propertyVector.isNull(pos)) {
-            auto* keyData = propertyVector.getData() + propertyVector.getNumBytesPerValue() * pos;
-            innerIndex->insertEntry(keyData, nodeOffset);
+        if (si.isComposite()) {
+            // For composite: get old composite key, split, replace updated component, rebuild
+            auto oldKeyStr = innerIndex->getKeyStringForOffset(nodeOffset);
+            innerIndex->deleteByOffset(nodeOffset);
+            if (!oldKeyStr.empty() && !propertyVector.isNull(pos)) {
+                auto parts = splitCompositeKey(oldKeyStr);
+                // Find which position in the composite the updated column occupies
+                auto updatedColumnID = updState.columnID;
+                for (size_t ci = 0; ci < si.columnIDs.size(); ci++) {
+                    if (si.columnIDs[ci] == updatedColumnID) {
+                        parts[ci] = vectorValueToString(&propertyVector, pos);
+                        break;
+                    }
+                }
+                auto newKey = buildCompositeKey(parts);
+                ku_string_t kuStr(newKey.data(), newKey.size());
+                innerIndex->insertEntry(reinterpret_cast<const uint8_t*>(&kuStr), nodeOffset);
+            }
+        } else {
+            // Single property update (original behavior)
+            innerIndex->deleteByOffset(nodeOffset);
+            if (!propertyVector.isNull(pos)) {
+                auto* keyData = propertyVector.getData() + propertyVector.getNumBytesPerValue() * pos;
+                innerIndex->insertEntry(keyData, nodeOffset);
+            }
         }
     }
-    auto& si = storageInfo->cast<SecondaryHashIndexStorageInfo>();
     si.numEntries = innerIndex->size();
 }
 
@@ -313,6 +385,42 @@ bool SecondaryHashIndex::lookup(const uint8_t* keyData,
     std::vector<offset_t>& result) const {
     std::lock_guard<std::mutex> lock(mtx);
     return innerIndex->lookupOffsets(keyData, result);
+}
+
+bool SecondaryHashIndex::lookupComposite(const std::string& compositeKey,
+    std::vector<offset_t>& result) const {
+    std::lock_guard<std::mutex> lock(mtx);
+    ku_string_t kuStr(compositeKey.data(), compositeKey.size());
+    return innerIndex->lookupOffsets(reinterpret_cast<const uint8_t*>(&kuStr), result);
+}
+
+std::string SecondaryHashIndex::buildCompositeKey(const std::vector<std::string>& values) {
+    std::string result;
+    for (size_t i = 0; i < values.size(); i++) {
+        if (i > 0) {
+            result += '\0';
+        }
+        result += values[i];
+    }
+    return result;
+}
+
+std::vector<std::string> SecondaryHashIndex::splitCompositeKey(const std::string& compositeKey) {
+    std::vector<std::string> parts;
+    size_t start = 0;
+    for (size_t i = 0; i < compositeKey.size(); i++) {
+        if (compositeKey[i] == '\0') {
+            parts.push_back(compositeKey.substr(start, i - start));
+            start = i + 1;
+        }
+    }
+    parts.push_back(compositeKey.substr(start));
+    return parts;
+}
+
+bool SecondaryHashIndex::isComposite() const {
+    auto& si = storageInfo->cast<SecondaryHashIndexStorageInfo>();
+    return si.isComposite();
 }
 
 } // namespace hash_index_extension

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -1009,4 +1009,197 @@ final class ConnectionTests: XCTestCase {
         )
         XCTAssertFalse(createdAgain)
     }
+
+    // MARK: - Composite Hash Index Tests
+
+    private func makeCompositeTestDb() throws -> (Database, Connection) {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+        _ = try conn.query("""
+            CREATE NODE TABLE Person(
+                id INT64, firstName STRING, lastName STRING, city STRING, age INT64,
+                PRIMARY KEY(id))
+        """)
+        _ = try conn.query("CREATE (:Person {id:1, firstName:'Ali', lastName:'Yilmaz', city:'Istanbul', age:30})")
+        _ = try conn.query("CREATE (:Person {id:2, firstName:'Veli', lastName:'Kaya', city:'Ankara', age:25})")
+        _ = try conn.query("CREATE (:Person {id:3, firstName:'Ayse', lastName:'Demir', city:'Istanbul', age:28})")
+        _ = try conn.query("CREATE (:Person {id:4, firstName:'Ali', lastName:'Kaya', city:'Izmir', age:35})")
+        return (memDb, conn)
+    }
+
+    // 1. Basic composite create/lookup/drop
+    func testCompositeIndexBasicCreateLookupDrop() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        try conn.createCompositeIndex(table: "Person", properties: ["firstName", "lastName"])
+        let results = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+        XCTAssertEqual(results.count, 1)
+        // Drop composite index
+        try conn.dropHashIndex(table: "Person", property: "firstName,lastName")
+        // Verify index is gone
+        let indexes = try conn.listHashIndexes(table: "Person")
+        XCTAssertFalse(indexes.contains("firstName,lastName"))
+    }
+
+    // 2. 2-property composite (firstName + lastName)
+    func testCompositeIndex2Property() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        try conn.createCompositeIndex(table: "Person", properties: ["firstName", "lastName"])
+        // Ali Yilmaz exists
+        let r1 = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+        XCTAssertEqual(r1.count, 1)
+        // Ali Kaya also exists
+        let r2 = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Kaya"])
+        XCTAssertEqual(r2.count, 1)
+        // Ali Demir does NOT exist
+        let r3 = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Demir"])
+        XCTAssertEqual(r3.count, 0)
+        try conn.dropHashIndex(table: "Person", property: "firstName,lastName")
+    }
+
+    // 3. 3-property composite (firstName + lastName + city)
+    func testCompositeIndex3Property() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        try conn.createCompositeIndex(table: "Person", properties: ["firstName", "lastName", "city"])
+        let results = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName", "city"],
+            values: ["Ali", "Yilmaz", "Istanbul"])
+        XCTAssertEqual(results.count, 1)
+        // Wrong city
+        let empty = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName", "city"],
+            values: ["Ali", "Yilmaz", "Ankara"])
+        XCTAssertEqual(empty.count, 0)
+        try conn.dropHashIndex(table: "Person", property: "firstName,lastName,city")
+    }
+
+    // 4. Non-unique composite (multiple nodes same combo)
+    func testCompositeIndexNonUnique() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        // Add another Ali Yilmaz
+        _ = try conn.query("CREATE (:Person {id:5, firstName:'Ali', lastName:'Yilmaz', city:'Bursa', age:40})")
+        try conn.createCompositeIndex(table: "Person", properties: ["firstName", "lastName"])
+        let results = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+        XCTAssertEqual(results.count, 2)
+        try conn.dropHashIndex(table: "Person", property: "firstName,lastName")
+    }
+
+    // 5. Insert sync — new node appears in composite index
+    func testCompositeIndexInsertSync() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        try conn.createCompositeIndex(table: "Person", properties: ["firstName", "lastName"])
+        // Insert new node
+        _ = try conn.query("CREATE (:Person {id:6, firstName:'Fatma', lastName:'Ozturk', city:'Antalya', age:22})")
+        let results = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Fatma", "Ozturk"])
+        XCTAssertEqual(results.count, 1)
+        try conn.dropHashIndex(table: "Person", property: "firstName,lastName")
+    }
+
+    // 6. Delete sync — deleted node removed from composite index
+    func testCompositeIndexDeleteSync() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        try conn.createCompositeIndex(table: "Person", properties: ["firstName", "lastName"])
+        // Verify Ali Yilmaz exists
+        let before = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+        XCTAssertEqual(before.count, 1)
+        // Delete Ali Yilmaz
+        _ = try conn.query("MATCH (p:Person) WHERE p.id = 1 DELETE p")
+        let after = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+        XCTAssertEqual(after.count, 0)
+        try conn.dropHashIndex(table: "Person", property: "firstName,lastName")
+    }
+
+    // 7. Update sync — property change updates composite index
+    func testCompositeIndexUpdateSync() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        try conn.createCompositeIndex(table: "Person", properties: ["firstName", "lastName"])
+        // Verify current combo exists
+        let before = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+        XCTAssertEqual(before.count, 1)
+        // Update lastName from Yilmaz to Ozcan
+        _ = try conn.query("MATCH (p:Person) WHERE p.id = 1 SET p.lastName = 'Ozcan'")
+        // Old combo should be gone
+        let afterOld = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+        XCTAssertEqual(afterOld.count, 0)
+        // New combo should exist
+        let afterNew = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "lastName"], values: ["Ali", "Ozcan"])
+        XCTAssertEqual(afterNew.count, 1)
+        try conn.dropHashIndex(table: "Person", property: "firstName,lastName")
+    }
+
+    // 8. Mixed types — string + int64 composite
+    func testCompositeIndexMixedTypes() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        try conn.createCompositeIndex(table: "Person", properties: ["firstName", "age"])
+        // Ali,30 exists
+        let results = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "age"], values: ["Ali", "30"])
+        XCTAssertEqual(results.count, 1)
+        // Ali,25 does NOT exist
+        let empty = try conn.lookupByCompositeIndex(
+            table: "Person", properties: ["firstName", "age"], values: ["Ali", "25"])
+        XCTAssertEqual(empty.count, 0)
+        try conn.dropHashIndex(table: "Person", property: "firstName,age")
+    }
+
+    // 9. Null property handling — composite key with null skips entry
+    func testCompositeIndexNullProperty() throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+        _ = try conn.query("""
+            CREATE NODE TABLE NullTest(
+                id INT64, firstName STRING, lastName STRING, PRIMARY KEY(id))
+        """)
+        _ = try conn.query("CREATE (:NullTest {id:1, firstName:'Ali', lastName:'Yilmaz'})")
+        // Insert node with null lastName
+        _ = try conn.query("CREATE (:NullTest {id:2, firstName:'Veli'})")
+        try conn.createCompositeIndex(table: "NullTest", properties: ["firstName", "lastName"])
+        // Ali,Yilmaz should be found
+        let r1 = try conn.lookupByCompositeIndex(
+            table: "NullTest", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+        XCTAssertEqual(r1.count, 1)
+        // Veli with null lastName should NOT be indexed (null skips)
+        let r2 = try conn.lookupByCompositeIndex(
+            table: "NullTest", properties: ["firstName", "lastName"], values: ["Veli", ""])
+        XCTAssertEqual(r2.count, 0)
+        try conn.dropHashIndex(table: "NullTest", property: "firstName,lastName")
+    }
+
+    // Test createCompositeIndexIfNotExists
+    func testCreateCompositeIndexIfNotExists() throws {
+        let (_, conn) = try makeCompositeTestDb()
+        let created = try conn.createCompositeIndexIfNotExists(
+            table: "Person", properties: ["firstName", "lastName"])
+        XCTAssertTrue(created)
+        let createdAgain = try conn.createCompositeIndexIfNotExists(
+            table: "Person", properties: ["firstName", "lastName"])
+        XCTAssertFalse(createdAgain)
+        try conn.dropHashIndex(table: "Person", property: "firstName,lastName")
+    }
 }


### PR DESCRIPTION
## Summary

Extend the existing SecondaryHashIndex to support multi-property composite keys. The existing single-property hash index continues working unchanged.

## Composite Key Strategy

Concatenate property values with null-byte separator:
```
firstName="Ali", lastName="Yılmaz" → "Ali\0Yılmaz"
age=30, city="Istanbul" → "30\0Istanbul"
```

The composite key is treated as a STRING type in the hash index.

## Changes

### C++ (hash_index extension)
- **SecondaryHashIndexStorageInfo**: Added `columnIDs` and `propertyNames` vectors for composite indexes, with `isComposite()` helper
- **SecondaryHashIndex**: Added `buildCompositeKey()`, `splitCompositeKey()`, `lookupComposite()` methods
- **insert()**: Builds composite key from multiple property vectors when composite
- **update()**: Reconstructs composite key via `getKeyStringForOffset()` reverse-map lookup, replaces the changed component
- **InnerSecondaryIndex**: Added `getKeyStringForOffset()` virtual method for reverse-map access
- **CREATE_HASH_INDEX**: Accepts comma-separated properties (e.g., `'firstName,lastName'`)
- **QUERY_HASH_INDEX**: Handles composite lookups with comma-separated values

### Swift API (Connection.swift)
- `createCompositeIndex(table:properties:)`
- `createCompositeIndexIfNotExists(table:properties:)` — idempotent
- `lookupByCompositeIndex(table:properties:values:)`

### Tests (10 new)
1. Basic composite create/lookup/drop
2. 2-property composite (firstName + lastName)
3. 3-property composite (firstName + lastName + city)
4. Non-unique composite (multiple nodes, same combo)
5. Insert sync — new node appears in composite index
6. Delete sync — deleted node removed from composite index
7. Update sync — property change updates composite key
8. Mixed types — string + int64 composite
9. Null property handling — nodes with null properties skipped
10. createCompositeIndexIfNotExists idempotent

## Verification

- `swift build` ✅
- `swift test --skip StressTests --skip ScaleTests` — 145 tests, 0 failures ✅
- Backward compatibility: all existing single-property hash index tests pass ✅

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author