### PR TITLE
feat: add BOOL type support to SecondaryHashIndex

### DIFF
--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/function/create_hash_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/function/create_hash_index.cpp
@@ -80,6 +80,7 @@ static void validateKeyType(PhysicalTypeID type) {
     case PhysicalTypeID::FLOAT:
     case PhysicalTypeID::DOUBLE:
     case PhysicalTypeID::STRING:
+    case PhysicalTypeID::BOOL:
         return;
     default:
         throw BinderException(

--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/function/query_hash_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/function/query_hash_index.cpp
@@ -127,6 +127,11 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
                 auto val = std::stof(lookupValue);
                 index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
             },
+            [&](bool) {
+                auto val = (lookupValue == "true" || lookupValue == "True" ||
+                            lookupValue == "TRUE" || lookupValue == "1");
+                index->lookup(reinterpret_cast<const uint8_t*>(&val), resultOffsets);
+            },
             [&](auto) {
                 throw BinderException("Unsupported key type for hash index query.");
             });

--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/index/secondary_hash_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/index/secondary_hash_index.cpp
@@ -195,6 +195,7 @@ template class TypedInnerSecondaryIndex<int16_t>;
 template class TypedInnerSecondaryIndex<int128_t>;
 template class TypedInnerSecondaryIndex<uint64_t>;
 template class TypedInnerSecondaryIndex<uint32_t>;
+template class TypedInnerSecondaryIndex<bool>;
 
 // ===========================================================================
 // SecondaryHashIndex – Insert / Delete / Update states (minimal)
@@ -246,6 +247,9 @@ void SecondaryHashIndex::initInnerIndex() {
         physType,
         [&](ku_string_t) {
             innerIndex = std::make_unique<TypedInnerSecondaryIndex<ku_string_t>>();
+        },
+        [&](bool) {
+            innerIndex = std::make_unique<TypedInnerSecondaryIndex<bool>>();
         },
         [&]<HashablePrimitive T>(T) {
             innerIndex = std::make_unique<TypedInnerSecondaryIndex<T>>();

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -682,6 +682,55 @@ final class ConnectionTests: XCTestCase {
         try conn.dropHashIndex(table: "HashIdxInt64Test", property: "age")
     }
 
+    func testHashIndexBoolProperty() throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        _ = try conn.query("CREATE NODE TABLE Item(id INT64, name STRING, isUtility BOOL, PRIMARY KEY(id))")
+        _ = try conn.query("CREATE (:Item {id: 1, name: 'Photo1', isUtility: true})")
+        _ = try conn.query("CREATE (:Item {id: 2, name: 'Photo2', isUtility: false})")
+        _ = try conn.query("CREATE (:Item {id: 3, name: 'Photo3', isUtility: true})")
+        _ = try conn.query("CREATE (:Item {id: 4, name: 'Screenshot', isUtility: false})")
+
+        // Create index on BOOL column
+        try conn.createHashIndex(table: "Item", property: "isUtility")
+
+        // Lookup true values — should find 2 (Photo1, Photo3)
+        let result = try conn.query("CALL QUERY_HASH_INDEX('Item', 'isUtility', 'true') RETURN node_id")
+        var trueCount = 0
+        while result.hasNext() {
+            let _ = try result.getNext()
+            trueCount += 1
+        }
+        result.close()
+        XCTAssertEqual(trueCount, 2)
+
+        // Lookup false values — should find 2 (Photo2, Screenshot)
+        let result2 = try conn.query("CALL QUERY_HASH_INDEX('Item', 'isUtility', 'false') RETURN node_id")
+        var falseCount = 0
+        while result2.hasNext() {
+            let _ = try result2.getNext()
+            falseCount += 1
+        }
+        result2.close()
+        XCTAssertEqual(falseCount, 2)
+
+        // createHashIndexIfNotExists should work without error
+        let created = try conn.createHashIndexIfNotExists(table: "Item", property: "isUtility")
+        XCTAssertFalse(created)  // already exists
+
+        // Drop
+        try conn.dropHashIndex(table: "Item", property: "isUtility")
+    }
+
     func testHashIndexEmptyTable() throws {
         let systemConfig = SystemConfig(
             bufferPoolSize: 256 * 1024 * 1024,


### PR DESCRIPTION
## Summary

Add BOOL type support to SecondaryHashIndex so that `createHashIndex(table:property:)` works on BOOL columns.

## Problem

`createHashIndexIfNotExists(table: "Image", property: "isUtility")` throws "Hash index does not support type BOOL". BOOL is stored as `uint8_t` (0/1) — there's no technical reason not to support it.

## Changes

### `create_hash_index.cpp`
- Add `PhysicalTypeID::BOOL` to `validateKeyType()` allowed types

### `secondary_hash_index.cpp`
- Add explicit `bool` handler in `initInnerIndex()` (BOOL dispatches to `bool` via `TypeUtils::visit`, which is excluded by the `HashablePrimitive` concept)
- Add `template class TypedInnerSecondaryIndex<bool>` explicit instantiation

### `query_hash_index.cpp`
- Add `bool` case to `TypeUtils::visit` dispatch for converting string lookup values (`"true"`/`"false"`) to `bool`

### `ConnectionTests.swift`
- Add `testHashIndexBoolProperty` test: creates BOOL column, indexes it, looks up `true`/`false` values, verifies counts, tests `createHashIndexIfNotExists` idempotency, and drops the index

## Test Results

146 tests pass, 0 failures.

Closes #52

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author