### PR TITLE
feat: WAL recovery reconciliation for extension-managed indexes

### DIFF
--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/include/main/hash_index_extension.h
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/include/main/hash_index_extension.h
@@ -11,6 +11,10 @@ public:
     static constexpr const char* EXTENSION_NAME = "HASH_INDEX";
 
     void load(main::ClientContext* context);
+
+    // Re-run index initialization after WAL recovery. This detects catalog index
+    // entries that have no corresponding IndexHolder in NodeTable and rebuilds them.
+    static void reconcileIndexes(main::ClientContext* context);
 };
 
 } // namespace hash_index_extension

--- a/Sources/cxx-kuzu/kuzu/extension/hash_index/src/main/hash_index_extension.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/hash_index/src/main/hash_index_extension.cpp
@@ -2,15 +2,152 @@
 
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/index_catalog_entry.h"
+#include "catalog/catalog_entry/table_catalog_entry.h"
 #include "extension/extension.h"
 #include "function/hash_index_functions.h"
 #include "index/secondary_hash_index.h"
+#include "main/client_context.h"
 #include "main/database.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
 
 namespace kuzu {
 namespace hash_index_extension {
+
+// Helper to split comma-separated string and trim whitespace.
+static std::vector<std::string> splitProperties(const std::string& props) {
+    std::vector<std::string> result;
+    size_t start = 0;
+    for (size_t i = 0; i <= props.size(); i++) {
+        if (i == props.size() || props[i] == ',') {
+            auto part = props.substr(start, i - start);
+            auto first = part.find_first_not_of(" \t");
+            auto last = part.find_last_not_of(" \t");
+            if (first != std::string::npos) {
+                result.push_back(part.substr(first, last - first + 1));
+            }
+            start = i + 1;
+        }
+    }
+    return result;
+}
+
+// Rebuild a secondary hash index from scratch by scanning all committed data.
+// This is used during WAL recovery when the catalog knows about the index but
+// NodeTable has no IndexHolder (because WAL replay only restores catalog entries).
+static void rebuildIndex(main::ClientContext* context, storage::StorageManager* storageManager,
+    catalog::IndexCatalogEntry* indexEntry) {
+    auto* catalog = context->getCatalog();
+    auto* transaction = context->getTransaction();
+    auto tableID = indexEntry->getTableID();
+    auto& nodeTable = storageManager->getTable(tableID)->cast<storage::NodeTable>();
+
+    // Look up the table catalog entry to resolve property names → column IDs & types.
+    auto* tableEntry = catalog->getTableCatalogEntry(transaction, tableID);
+    auto indexName = indexEntry->getIndexName();
+    auto propNames = splitProperties(indexName);
+    auto hashType = SecondaryHashIndex::getIndexType();
+
+    if (propNames.size() > 1) {
+        // === Composite index ===
+        std::vector<common::column_id_t> colIDs;
+        std::vector<common::LogicalType> logTypes;
+        for (auto& pn : propNames) {
+            if (!tableEntry->containsProperty(pn)) return;
+            colIDs.push_back(tableEntry->getColumnID(pn));
+            logTypes.push_back(tableEntry->getProperty(pn).getType().copy());
+        }
+        std::vector<common::PhysicalTypeID> keyTypes{common::PhysicalTypeID::STRING};
+        storage::IndexInfo indexInfo{indexName, hashType.typeName, tableID,
+            colIDs, keyTypes,
+            hashType.constraintType == storage::IndexConstraintType::PRIMARY,
+            hashType.definitionType == storage::IndexDefinitionType::BUILTIN};
+
+        auto storageInfoPtr = std::make_unique<SecondaryHashIndexStorageInfo>(
+            0, colIDs, propNames);
+        auto index = std::make_unique<SecondaryHashIndex>(
+            std::move(indexInfo), std::move(storageInfoPtr));
+
+        auto numNodeGroups = nodeTable.getNumCommittedNodeGroups();
+        if (numNodeGroups > 0) {
+            std::vector<common::LogicalType> types;
+            for (auto& lt : logTypes) types.push_back(lt.copy());
+            auto dataChunk = storage::Table::constructDataChunk(
+                context->getMemoryManager(), std::move(types));
+            std::vector<common::ValueVector*> outVectors;
+            for (uint32_t c = 0; c < colIDs.size(); c++) {
+                outVectors.push_back(&dataChunk.getValueVectorMutable(c));
+            }
+            auto nodeIDVector = std::make_unique<common::ValueVector>(
+                common::LogicalType::INTERNAL_ID(), context->getMemoryManager());
+            nodeIDVector->setState(dataChunk.state);
+
+            auto scanState = std::make_unique<storage::NodeTableScanState>(
+                nodeIDVector.get(), outVectors, dataChunk.state);
+            scanState->setToTable(transaction, &nodeTable, colIDs, {});
+
+            auto insertState = index->initInsertState(context, nullptr);
+
+            for (common::node_group_idx_t ng = 0; ng < numNodeGroups; ng++) {
+                scanState->source = storage::TableScanSource::COMMITTED;
+                scanState->nodeGroupIdx = ng;
+                nodeTable.initScanState(transaction, *scanState);
+                while (nodeTable.scan(transaction, *scanState)) {
+                    if (dataChunk.state->getSelSize() == 0) continue;
+                    index->insert(transaction, *nodeIDVector, outVectors, *insertState);
+                }
+            }
+        }
+        nodeTable.addIndex(std::move(index));
+    } else {
+        // === Single property index ===
+        auto& propertyName = propNames[0];
+        if (!tableEntry->containsProperty(propertyName)) return;
+        auto columnID = tableEntry->getColumnID(propertyName);
+        auto keyType = tableEntry->getProperty(propertyName).getType().getPhysicalType();
+        auto logicalType = tableEntry->getProperty(propertyName).getType().copy();
+
+        storage::IndexInfo indexInfo{propertyName, hashType.typeName, tableID,
+            {columnID}, {keyType},
+            hashType.constraintType == storage::IndexConstraintType::PRIMARY,
+            hashType.definitionType == storage::IndexDefinitionType::BUILTIN};
+
+        auto storageInfoPtr = std::make_unique<SecondaryHashIndexStorageInfo>(0, columnID);
+        auto index = std::make_unique<SecondaryHashIndex>(
+            std::move(indexInfo), std::move(storageInfoPtr));
+
+        auto numNodeGroups = nodeTable.getNumCommittedNodeGroups();
+        if (numNodeGroups > 0) {
+            std::vector<common::LogicalType> types;
+            types.push_back(logicalType.copy());
+            auto dataChunk = storage::Table::constructDataChunk(
+                context->getMemoryManager(), std::move(types));
+            auto* propVector = &dataChunk.getValueVectorMutable(0);
+            auto nodeIDVector = std::make_unique<common::ValueVector>(
+                common::LogicalType::INTERNAL_ID(), context->getMemoryManager());
+            nodeIDVector->setState(dataChunk.state);
+
+            std::vector<common::ValueVector*> outVectors{propVector};
+            auto scanState = std::make_unique<storage::NodeTableScanState>(
+                nodeIDVector.get(), outVectors, dataChunk.state);
+            scanState->setToTable(transaction, &nodeTable, {columnID}, {});
+
+            auto insertState = index->initInsertState(context, nullptr);
+
+            for (common::node_group_idx_t ng = 0; ng < numNodeGroups; ng++) {
+                scanState->source = storage::TableScanSource::COMMITTED;
+                scanState->nodeGroupIdx = ng;
+                nodeTable.initScanState(transaction, *scanState);
+                while (nodeTable.scan(transaction, *scanState)) {
+                    if (dataChunk.state->getSelSize() == 0) continue;
+                    std::vector<common::ValueVector*> indexVectors{propVector};
+                    index->insert(transaction, *nodeIDVector, indexVectors, *insertState);
+                }
+            }
+        }
+        nodeTable.addIndex(std::move(index));
+    }
+}
 
 static void initHashIndexEntries(main::ClientContext* context) {
     auto* storageManager = context->getStorageManager();
@@ -26,15 +163,24 @@ static void initHashIndexEntries(main::ClientContext* context) {
         return;
     }
     for (auto& indexEntry : catalog->getIndexEntries(transaction)) {
-        if (indexEntry->getIndexType() == "HASH" && !indexEntry->isLoaded()) {
+        if (indexEntry->getIndexType() != "HASH") {
+            continue;
+        }
+        if (!indexEntry->isLoaded()) {
             // Set auxInfo so the catalog entry is marked as loaded.
             indexEntry->setAuxInfo(std::make_unique<HashIndexAuxInfo>());
-            auto& nodeTable =
-                storageManager->getTable(indexEntry->getTableID())->cast<storage::NodeTable>();
-            auto optionalIndex = nodeTable.getIndexHolder(indexEntry->getIndexName());
-            if (optionalIndex.has_value() && !optionalIndex.value().get().isLoaded()) {
+        }
+        auto& nodeTable =
+            storageManager->getTable(indexEntry->getTableID())->cast<storage::NodeTable>();
+        auto optionalIndex = nodeTable.getIndexHolder(indexEntry->getIndexName());
+        if (optionalIndex.has_value()) {
+            // IndexHolder exists but may not be loaded yet.
+            if (!optionalIndex.value().get().isLoaded()) {
                 optionalIndex.value().get().load(context, storageManager);
             }
+        } else {
+            // No IndexHolder in NodeTable — rebuild from scratch (WAL recovery case).
+            rebuildIndex(context, storageManager, indexEntry);
         }
     }
 }
@@ -46,6 +192,10 @@ void HashIndexExtension::load(main::ClientContext* context) {
     extension::ExtensionUtils::addTableFunc<QueryHashIndexFunction>(db);
     extension::ExtensionUtils::addTableFunc<ListHashIndexesFunction>(db);
     extension::ExtensionUtils::registerIndexType(db, SecondaryHashIndex::getIndexType());
+    initHashIndexEntries(context);
+}
+
+void HashIndexExtension::reconcileIndexes(main::ClientContext* context) {
     initHashIndexEntries(context);
 }
 

--- a/Sources/cxx-kuzu/kuzu/src/extension/extension_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/extension/extension_manager.cpp
@@ -5,6 +5,7 @@
 #include "common/string_utils.h"
 #include "extension/extension.h"
 #include "generated_extension_loader.h"
+#include "hash_index_extension.h"
 #include "storage/wal/local_wal.h"
 
 namespace kuzu {
@@ -96,6 +97,16 @@ void ExtensionManager::autoLoadLinkedExtensions(main::ClientContext* context) {
     auto trxContext = context->getTransactionContext();
     trxContext->beginRecoveryTransaction();
     loadLinkedExtensions(context, loadedExtensions);
+    trxContext->commit();
+}
+
+void ExtensionManager::reconcileAfterRecovery(main::ClientContext* context) {
+    // After WAL replay, extension-managed indexes may exist in the catalog but not
+    // in the NodeTable (because WAL only replays catalog entries, not IndexHolders).
+    // Re-run the hash index reconciliation to detect missing IndexHolders and rebuild them.
+    auto trxContext = context->getTransactionContext();
+    trxContext->beginRecoveryTransaction();
+    hash_index_extension::HashIndexExtension::reconcileIndexes(context);
     trxContext->commit();
 }
 

--- a/Sources/cxx-kuzu/kuzu/src/include/extension/extension_manager.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/extension/extension_manager.h
@@ -39,6 +39,10 @@ public:
 
     void autoLoadLinkedExtensions(main::ClientContext* context);
 
+    // Re-run extension init functions after WAL recovery to reconcile any
+    // extension-managed indexes that were created by replayed WAL records.
+    void reconcileAfterRecovery(main::ClientContext* context);
+
     bool isStaticLinkedExtension(const std::string& extensionName);
 
 private:

--- a/Sources/cxx-kuzu/kuzu/src/include/storage/storage_manager.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/storage/storage_manager.h
@@ -56,6 +56,10 @@ public:
     }
     std::optional<std::reference_wrapper<const IndexType>> getIndexType(
         const std::string& typeName) const;
+    // Lookup by typeName AND definitionType to disambiguate between builtin and
+    // extension index types that share the same typeName (e.g. both "HASH").
+    std::optional<std::reference_wrapper<const IndexType>> getIndexType(
+        const std::string& typeName, IndexDefinitionType definitionType) const;
 
     void serialize(const catalog::Catalog& catalog, common::Serializer& ser);
     // We need to pass in the catalog and storageManager explicitly as they can be from

--- a/Sources/cxx-kuzu/kuzu/src/storage/index/index.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/index/index.cpp
@@ -93,7 +93,17 @@ void IndexHolder::load(main::ClientContext* context, StorageManager* storageMana
     }
     KU_ASSERT(!index);
     KU_ASSERT(storageInfoBuffer);
-    auto indexTypeOptional = context->getStorageManager()->getIndexType(indexInfo.indexType);
+    // Use the more specific lookup that matches both typeName AND definitionType to
+    // disambiguate between builtin and extension index types sharing the same name
+    // (e.g. PrimaryKeyIndex "HASH" vs SecondaryHashIndex "HASH").
+    auto defType = indexInfo.isBuiltin ? IndexDefinitionType::BUILTIN :
+                                         IndexDefinitionType::EXTENSION;
+    auto indexTypeOptional =
+        context->getStorageManager()->getIndexType(indexInfo.indexType, defType);
+    if (!indexTypeOptional.has_value()) {
+        // Fall back to name-only lookup for backward compatibility.
+        indexTypeOptional = context->getStorageManager()->getIndexType(indexInfo.indexType);
+    }
     if (!indexTypeOptional.has_value()) {
         throw common::RuntimeException("No index type with name: " + indexInfo.indexType);
     }

--- a/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
@@ -207,6 +207,17 @@ std::optional<std::reference_wrapper<const IndexType>> StorageManager::getIndexT
     return std::nullopt;
 }
 
+std::optional<std::reference_wrapper<const IndexType>> StorageManager::getIndexType(
+    const std::string& typeName, IndexDefinitionType definitionType) const {
+    for (auto& indexType : registeredIndexTypes) {
+        if (StringUtils::caseInsensitiveEquals(indexType.typeName, typeName) &&
+            indexType.definitionType == definitionType) {
+            return indexType;
+        }
+    }
+    return std::nullopt;
+}
+
 void StorageManager::serialize(const Catalog& catalog, Serializer& ser) {
     std::lock_guard lck{mtx};
     auto nodeTableEntries = catalog.getNodeTableEntries(&DUMMY_CHECKPOINT_TRANSACTION);

--- a/Sources/cxx-kuzu/kuzu/src/storage/wal/wal_replayer.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/wal/wal_replayer.cpp
@@ -1,6 +1,8 @@
 #include "storage/wal/wal_replayer.h"
 
 #include "binder/binder.h"
+#include "catalog/catalog.h"
+#include "catalog/catalog_entry/index_catalog_entry.h"
 #include "catalog/catalog_entry/scalar_macro_catalog_entry.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
@@ -149,6 +151,11 @@ void WALReplayer::replay() const {
                 auto walRecord = WALRecord::deserialize(deserializer, clientContext);
                 replayWALRecord(*walRecord);
             }
+            // After WAL replay, reconcile extension-managed indexes. WAL replay only
+            // restores catalog INDEX_ENTRY records but does not rebuild the actual
+            // IndexHolder objects in NodeTable. This call re-runs extension init
+            // functions which detect missing IndexHolders and rebuild them.
+            clientContext.getExtensionManager()->reconcileAfterRecovery(&clientContext);
             // After replaying all the records, we should truncate the WAL file to the last
             // COMMIT/CHECKPOINT record.
             truncateWALFile(*fileInfo, offsetDeserialized);
@@ -310,6 +317,23 @@ void WALReplayer::replayDropCatalogEntryRecord(const WALRecord& walRecord) const
         catalog->dropSequence(transaction, entryID);
     } break;
     case CatalogEntryType::INDEX_ENTRY: {
+        // Before dropping the catalog entry, try to remove the corresponding
+        // IndexHolder from NodeTable (if it was loaded by an extension).
+        auto storageManager = clientContext.getStorageManager();
+        auto indexEntries = catalog->getIndexEntries(transaction);
+        for (auto* idxEntry : indexEntries) {
+            if (idxEntry->getOID() == entryID) {
+                auto* table = storageManager->getTable(idxEntry->getTableID());
+                if (table) {
+                    auto& nodeTable = table->cast<NodeTable>();
+                    auto optIdx = nodeTable.getIndexHolder(idxEntry->getIndexName());
+                    if (optIdx.has_value()) {
+                        nodeTable.dropIndex(idxEntry->getIndexName());
+                    }
+                }
+                break;
+            }
+        }
         catalog->dropIndex(transaction, entryID);
     } break;
     default: {

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -1251,4 +1251,216 @@ final class ConnectionTests: XCTestCase {
         XCTAssertFalse(createdAgain)
         try conn.dropHashIndex(table: "Person", property: "firstName,lastName")
     }
+
+    // MARK: - WAL Recovery Tests
+
+    /// Test that a hash index survives DB close and reopen (with checkpoint).
+    func testHashIndexSurvivesReopen() throws {
+        let dbPath = NSTemporaryDirectory() + "kuzu_wal_reopen_" + UUID().uuidString
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let config = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 1,
+            autoCheckpoint: true
+        )
+
+        // Phase 1: Create table, insert data, create index, close DB
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            _ = try conn.query(
+                "CREATE NODE TABLE WalTest(id INT64, email STRING, PRIMARY KEY(id))")
+            _ = try conn.query("CREATE (:WalTest {id:1, email:'a@test.com'})")
+            _ = try conn.query("CREATE (:WalTest {id:2, email:'b@test.com'})")
+            _ = try conn.query("CREATE (:WalTest {id:3, email:'c@test.com'})")
+            try conn.createHashIndex(table: "WalTest", property: "email")
+            // Verify index works before close
+            let r = try conn.lookupByIndex(table: "WalTest", property: "email", value: "a@test.com")
+            XCTAssertEqual(r.count, 1)
+        }
+
+        // Phase 2: Reopen DB and verify index still works
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+
+            // First verify data is there
+            let countResult = try conn.query("MATCH (p:WalTest) RETURN count(p)")
+            XCTAssertTrue(countResult.hasNext())
+            let countTuple = try countResult.getNext()!
+            let count = try countTuple.getValue(0) as! Int64
+            XCTAssertEqual(count, 3, "Data should persist after restart")
+
+            let has = try conn.hasHashIndex(table: "WalTest", property: "email")
+            XCTAssertTrue(has, "Index should exist after reopen")
+            let r1 = try conn.lookupByIndex(table: "WalTest", property: "email", value: "a@test.com")
+            XCTAssertEqual(r1.count, 1, "Should find 'a@test.com' after reopen")
+            let r2 = try conn.lookupByIndex(table: "WalTest", property: "email", value: "b@test.com")
+            XCTAssertEqual(r2.count, 1, "Should find 'b@test.com' after reopen")
+            let r3 = try conn.lookupByIndex(table: "WalTest", property: "email", value: "nonexistent@test.com")
+            XCTAssertEqual(r3.count, 0, "Should not find nonexistent value")
+            try conn.dropHashIndex(table: "WalTest", property: "email")
+        }
+    }
+
+    /// Test that a hash index survives DB close without explicit checkpoint (WAL recovery).
+    func testHashIndexSurvivesReopenWithoutCheckpoint() throws {
+        let dbPath = NSTemporaryDirectory() + "kuzu_wal_nocp_" + UUID().uuidString
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        // Disable auto-checkpoint so index creation is only in WAL
+        let config = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 1,
+            autoCheckpoint: false
+        )
+
+        // Phase 1: Create table, insert data, create index (no checkpoint)
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            _ = try conn.query(
+                "CREATE NODE TABLE WalNoCp(id INT64, name STRING, PRIMARY KEY(id))")
+            _ = try conn.query("CREATE (:WalNoCp {id:1, name:'Alice'})")
+            _ = try conn.query("CREATE (:WalNoCp {id:2, name:'Bob'})")
+            try conn.createHashIndex(table: "WalNoCp", property: "name")
+            let r = try conn.lookupByIndex(table: "WalNoCp", property: "name", value: "Alice")
+            XCTAssertEqual(r.count, 1)
+        }
+
+        // Phase 2: Reopen — WAL recovery should rebuild the index
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            let has = try conn.hasHashIndex(table: "WalNoCp", property: "name")
+            XCTAssertTrue(has, "Index should exist after WAL recovery")
+            let r1 = try conn.lookupByIndex(table: "WalNoCp", property: "name", value: "Alice")
+            XCTAssertEqual(r1.count, 1, "Should find 'Alice' after WAL recovery")
+            let r2 = try conn.lookupByIndex(table: "WalNoCp", property: "name", value: "Bob")
+            XCTAssertEqual(r2.count, 1, "Should find 'Bob' after WAL recovery")
+            try conn.dropHashIndex(table: "WalNoCp", property: "name")
+        }
+    }
+
+    /// Test that dropping a hash index survives DB close and reopen.
+    func testDropHashIndexSurvivesReopen() throws {
+        let dbPath = NSTemporaryDirectory() + "kuzu_wal_drop_" + UUID().uuidString
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let config = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 1,
+            autoCheckpoint: true
+        )
+
+        // Phase 1: Create table, data, index, then drop the index
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            _ = try conn.query(
+                "CREATE NODE TABLE WalDrop(id INT64, email STRING, PRIMARY KEY(id))")
+            _ = try conn.query("CREATE (:WalDrop {id:1, email:'x@test.com'})")
+            try conn.createHashIndex(table: "WalDrop", property: "email")
+            let has = try conn.hasHashIndex(table: "WalDrop", property: "email")
+            XCTAssertTrue(has)
+            try conn.dropHashIndex(table: "WalDrop", property: "email")
+            let hasAfter = try conn.hasHashIndex(table: "WalDrop", property: "email")
+            XCTAssertFalse(hasAfter)
+        }
+
+        // Phase 2: Reopen and verify index is still gone
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            let has = try conn.hasHashIndex(table: "WalDrop", property: "email")
+            XCTAssertFalse(has, "Dropped index should not exist after reopen")
+        }
+    }
+
+    /// Test that a composite index survives DB close and reopen.
+    func testCompositeIndexSurvivesReopen() throws {
+        let dbPath = NSTemporaryDirectory() + "kuzu_wal_composite_" + UUID().uuidString
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let config = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 1,
+            autoCheckpoint: true
+        )
+
+        // Phase 1: Create table, data, composite index
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            _ = try conn.query("""
+                CREATE NODE TABLE WalComp(
+                    id INT64, firstName STRING, lastName STRING, PRIMARY KEY(id))
+            """)
+            _ = try conn.query("CREATE (:WalComp {id:1, firstName:'Ali', lastName:'Yilmaz'})")
+            _ = try conn.query("CREATE (:WalComp {id:2, firstName:'Veli', lastName:'Kaya'})")
+            _ = try conn.query("CREATE (:WalComp {id:3, firstName:'Ali', lastName:'Kaya'})")
+            try conn.createCompositeIndex(table: "WalComp", properties: ["firstName", "lastName"])
+            let r = try conn.lookupByCompositeIndex(
+                table: "WalComp", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+            XCTAssertEqual(r.count, 1)
+        }
+
+        // Phase 2: Reopen and verify composite index works
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            let has = try conn.hasHashIndex(table: "WalComp", property: "firstName,lastName")
+            XCTAssertTrue(has, "Composite index should exist after reopen")
+            let r1 = try conn.lookupByCompositeIndex(
+                table: "WalComp", properties: ["firstName", "lastName"], values: ["Ali", "Yilmaz"])
+            XCTAssertEqual(r1.count, 1, "Should find Ali Yilmaz after reopen")
+            let r2 = try conn.lookupByCompositeIndex(
+                table: "WalComp", properties: ["firstName", "lastName"], values: ["Veli", "Kaya"])
+            XCTAssertEqual(r2.count, 1, "Should find Veli Kaya after reopen")
+            let r3 = try conn.lookupByCompositeIndex(
+                table: "WalComp", properties: ["firstName", "lastName"], values: ["Ali", "Kaya"])
+            XCTAssertEqual(r3.count, 1, "Should find Ali Kaya after reopen")
+            try conn.dropHashIndex(table: "WalComp", property: "firstName,lastName")
+        }
+    }
+
+    /// Test that a BOOL property index survives DB close and reopen.
+    func testBoolIndexSurvivesReopen() throws {
+        let dbPath = NSTemporaryDirectory() + "kuzu_wal_bool_" + UUID().uuidString
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let config = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 1,
+            autoCheckpoint: true
+        )
+
+        // Phase 1: Create table with BOOL, data, index
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            _ = try conn.query(
+                "CREATE NODE TABLE WalBool(id INT64, active BOOL, PRIMARY KEY(id))")
+            _ = try conn.query("CREATE (:WalBool {id:1, active:true})")
+            _ = try conn.query("CREATE (:WalBool {id:2, active:false})")
+            _ = try conn.query("CREATE (:WalBool {id:3, active:true})")
+            try conn.createHashIndex(table: "WalBool", property: "active")
+            let r = try conn.lookupByIndex(table: "WalBool", property: "active", value: "true")
+            XCTAssertEqual(r.count, 2)
+        }
+
+        // Phase 2: Reopen and verify BOOL index works
+        do {
+            let diskDb = try Database(dbPath, config)
+            let conn = try Connection(diskDb)
+            let has = try conn.hasHashIndex(table: "WalBool", property: "active")
+            XCTAssertTrue(has, "Bool index should exist after reopen")
+            let rTrue = try conn.lookupByIndex(table: "WalBool", property: "active", value: "true")
+            XCTAssertEqual(rTrue.count, 2, "Should find 2 active=true after reopen")
+            let rFalse = try conn.lookupByIndex(table: "WalBool", property: "active", value: "false")
+            XCTAssertEqual(rFalse.count, 1, "Should find 1 active=false after reopen")
+            try conn.dropHashIndex(table: "WalBool", property: "active")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a critical database integrity issue where extension-managed indexes (secondary hash indexes) become inconsistent after crash recovery. Closes #56.

## Root Cause

`CREATE_HASH_INDEX` performs three operations:
1. `catalog->createIndex()` — logged to WAL ✅
2. `nodeTable.addIndex()` — NOT logged ❌
3. Full table scan to populate index — NOT logged ❌

During WAL recovery, only step 1 was replayed. The NodeTable never received the IndexHolder, and the index data was never repopulated.

## Changes

### 1. Post-WAL-Replay Index Reconciliation
- Added `ExtensionManager::reconcileAfterRecovery()` — called after WAL replay completes
- Added `HashIndexExtension::reconcileIndexes()` — re-runs `initHashIndexEntries()` post-replay
- Updated `initHashIndexEntries()` to handle the "catalog entry exists but no IndexHolder" case by creating + populating the index via full table scan

### 2. IndexHolder::load Type Disambiguation (Pre-existing Bug Fix)
- **Bug**: Both `PrimaryKeyIndex` and `SecondaryHashIndex` registered as type `"HASH"`. `IndexHolder::load()` used `getIndexType("HASH")` which always returned the PrimaryKeyIndex's `loadFunc`, causing a crash when loading a persisted SecondaryHashIndex.
- **Fix**: Added `getIndexType(typeName, definitionType)` overload to `StorageManager`. Updated `IndexHolder::load()` to use `isBuiltin` flag for disambiguation.

### 3. DROP INDEX WAL Replay Fix
- `replayDropCatalogEntryRecord` for `INDEX_ENTRY` now also removes the index from the corresponding NodeTable.

### 4. Crash Recovery Tests (5 new tests)
- `testHashIndexSurvivesReopen` — create index → close → reopen → verify
- `testHashIndexSurvivesReopenWithoutCheckpoint` — no explicit checkpoint
- `testDropHashIndexSurvivesReopen` — drop persists across restart
- `testCompositeIndexSurvivesReopen` — composite key survival
- `testBoolIndexSurvivesReopen` — BOOL property index survival

## Files Changed
- `extension/hash_index/src/include/main/hash_index_extension.h` — `reconcileIndexes()` declaration
- `extension/hash_index/src/main/hash_index_extension.cpp` — rebuild logic + reconcile
- `src/extension/extension_manager.cpp` — `reconcileAfterRecovery()`
- `src/include/extension/extension_manager.h` — declaration
- `src/include/storage/storage_manager.h` — `getIndexType()` overload
- `src/storage/index/index.cpp` — `IndexHolder::load()` disambiguation
- `src/storage/storage_manager.cpp` — `getIndexType()` implementation
- `src/storage/wal/wal_replayer.cpp` — reconcile hook + DROP fix
- `Tests/kuzu-swiftTests/ConnectionTests.swift` — 5 new tests

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author