### PR TITLE
fix: MERGE ON CREATE SET works with indexed properties

### DIFF
--- a/Sources/cxx-kuzu/kuzu/src/binder/bind/bind_updating_clause.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/binder/bind/bind_updating_clause.cpp
@@ -108,7 +108,8 @@ std::unique_ptr<BoundUpdatingClause> Binder::bindMergeClause(const UpdatingClaus
     }
     if (mergeClause.hasOnCreateSetItems()) {
         for (auto& [lhs, rhs] : mergeClause.getOnCreateSetItemsRef()) {
-            auto setPropertyInfo = bindSetPropertyInfo(lhs.get(), rhs.get());
+            auto setPropertyInfo =
+                bindSetPropertyInfo(lhs.get(), rhs.get(), true /* skipIndexCheck */);
             boundMergeClause->addOnCreateSetPropertyInfo(std::move(setPropertyInfo));
         }
     }
@@ -284,7 +285,7 @@ std::unique_ptr<BoundUpdatingClause> Binder::bindSetClause(const UpdatingClause&
 }
 
 BoundSetPropertyInfo Binder::bindSetPropertyInfo(const ParsedExpression* column,
-    const ParsedExpression* columnData) {
+    const ParsedExpression* columnData, bool skipIndexCheck) {
     auto expr = expressionBinder.bindExpression(*column->getChild(0));
     auto isNode = ExpressionUtil::isNodePattern(*expr);
     auto isRel = ExpressionUtil::isRelPattern(*expr);
@@ -298,20 +299,24 @@ BoundSetPropertyInfo Binder::bindSetPropertyInfo(const ParsedExpression* column,
     auto boundColumnData = boundSetItem.second;
     auto& nodeOrRel = expr->constCast<NodeOrRelExpression>();
     auto& property = boundSetItem.first->constCast<PropertyExpression>();
-    // Check secondary index constraint
-    auto catalog = clientContext->getCatalog();
-    auto transaction = clientContext->getTransaction();
-    for (auto entry : nodeOrRel.getEntries()) {
-        // When setting multi labeled node, skip checking if property is not in current table.
-        if (!property.hasProperty(entry->getTableID())) {
-            continue;
-        }
-        auto propertyID = entry->getPropertyID(property.getPropertyName());
-        if (catalog->containsUnloadedIndex(transaction, entry->getTableID(), propertyID)) {
-            throw BinderException(
-                stringFormat("Cannot set property {} in table {} because it is used in one or more "
-                             "indexes which is unloaded.",
+    // Check secondary index constraint.
+    // Skip for ON CREATE SET in MERGE statements because the node is being created (INSERT),
+    // and INSERT already handles index updates correctly through NodeTable::insert().
+    if (!skipIndexCheck) {
+        auto catalog = clientContext->getCatalog();
+        auto transaction = clientContext->getTransaction();
+        for (auto entry : nodeOrRel.getEntries()) {
+            // When setting multi labeled node, skip checking if property is not in current table.
+            if (!property.hasProperty(entry->getTableID())) {
+                continue;
+            }
+            auto propertyID = entry->getPropertyID(property.getPropertyName());
+            if (catalog->containsUnloadedIndex(transaction, entry->getTableID(), propertyID)) {
+                throw BinderException(stringFormat(
+                    "Cannot set property {} in table {} because it is used in one or more "
+                    "indexes which is unloaded.",
                     property.getPropertyName(), entry->getName()));
+            }
         }
     }
     // Check primary key constraint

--- a/Sources/cxx-kuzu/kuzu/src/include/binder/binder.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/binder/binder.h
@@ -249,7 +249,7 @@ public:
         const std::vector<PropertyDefinition>& propertyDefinitions);
 
     BoundSetPropertyInfo bindSetPropertyInfo(const parser::ParsedExpression* column,
-        const parser::ParsedExpression* columnData);
+        const parser::ParsedExpression* columnData, bool skipIndexCheck = false);
     expression_pair bindSetItem(const parser::ParsedExpression* column,
         const parser::ParsedExpression* columnData);
 

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -2066,4 +2066,77 @@ final class ConnectionTests: XCTestCase {
         try conn.dropRelIndex(table: "REL_A", property: "score")
         try conn.dropRelIndex(table: "REL_B", property: "score")
     }
+
+    // MARK: - MERGE ON CREATE SET with Index (Issue #62)
+
+    /// Regression test for GitHub issue #62: MERGE ON CREATE SET fails when a secondary
+    /// hash index exists on the property being set. ON CREATE SET is semantically an INSERT,
+    /// so the secondary index constraint check should be skipped.
+    func testMergeOnCreateSetWithIndex() throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        _ = try conn.query(
+            "CREATE NODE TABLE MergePerson(id INT64, name STRING, email STRING, PRIMARY KEY(id))"
+        )
+        _ = try conn.query(
+            "CREATE (:MergePerson {id: 1, name: 'Alice', email: 'alice@test.com'})"
+        )
+
+        // Create secondary hash index on email
+        try conn.createHashIndex(table: "MergePerson", property: "email")
+
+        // MERGE with ON CREATE SET on an indexed property should NOT throw
+        _ = try conn.query(
+            "MERGE (p:MergePerson {id: 2}) ON CREATE SET p.email = 'bob@test.com', p.name = 'Bob'"
+        )
+
+        // Verify the merge created the node
+        let result = try conn.query("MATCH (p:MergePerson {id: 2}) RETURN p.email, p.name")
+        XCTAssertTrue(result.hasNext())
+        let tuple = try result.getNext()!
+        let email = try tuple.getValue(0) as! String
+        let name = try tuple.getValue(1) as! String
+        XCTAssertEqual(email, "bob@test.com")
+        XCTAssertEqual(name, "Bob")
+
+        // Verify the index was updated with the new node's email
+        let indexResult = try conn.lookupByIndex(
+            table: "MergePerson", property: "email", value: "bob@test.com"
+        )
+        XCTAssertEqual(indexResult.count, 1, "New node should be findable via index")
+
+        // ON MATCH SET on indexed property should also work (updates existing node)
+        _ = try conn.query(
+            "MERGE (p:MergePerson {id: 1}) ON MATCH SET p.email = 'alice2@test.com'"
+        )
+
+        // Verify the update
+        let result2 = try conn.query("MATCH (p:MergePerson {id: 1}) RETURN p.email")
+        XCTAssertTrue(result2.hasNext())
+        let tuple2 = try result2.getNext()!
+        let updatedEmail = try tuple2.getValue(0) as! String
+        XCTAssertEqual(updatedEmail, "alice2@test.com")
+
+        // Verify index reflects the update
+        let oldLookup = try conn.lookupByIndex(
+            table: "MergePerson", property: "email", value: "alice@test.com"
+        )
+        XCTAssertEqual(oldLookup.count, 0, "Old email should not be in index")
+
+        let newLookup = try conn.lookupByIndex(
+            table: "MergePerson", property: "email", value: "alice2@test.com"
+        )
+        XCTAssertEqual(newLookup.count, 1, "Updated email should be in index")
+
+        try conn.dropHashIndex(table: "MergePerson", property: "email")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes issue #62 — `MERGE (n:Node {id: x}) ON CREATE SET n.prop = val` fails with `Cannot set property because it is used in one or more indexes` when a secondary index exists on the property.

## Root Cause

`bindSetPropertyInfo()` in `bind_updating_clause.cpp` checks for secondary index constraints on ALL SET operations, including ON CREATE SET. But ON CREATE SET is semantically an INSERT — the node doesn't exist yet, so the index check is wrong.

## Fix

Added `skipIndexCheck` parameter to `bindSetPropertyInfo()`. ON CREATE SET in MERGE passes `true` to skip the check. ON MATCH SET and standalone SET still check indexes.

## Files Changed
- `src/binder/bind/bind_updating_clause.cpp` — `skipIndexCheck` param + ON CREATE SET bypass
- `src/include/binder/binder.h` — updated declaration
- `Tests/kuzu-swiftTests/ConnectionTests.swift` — regression test

Closes #62

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author