### PR TITLE
Fix SIGABRT crash in LocalRelTable::delete_ for FWD-only rel tables (#66)

### DIFF
--- a/Sources/cxx-kuzu/kuzu/src/storage/local_storage/local_rel_table.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/local_storage/local_rel_table.cpp
@@ -111,20 +111,17 @@ bool LocalRelTable::delete_(Transaction* transaction, TableDeleteState& state) {
     const auto& deleteState = state.cast<RelTableDeleteState>();
 
     std::vector<row_idx_vec_t*> rowIndicesToDeleteFrom;
-    auto& directedIndex =
-        directedIndices[RelDirectionUtils::relDirectionToKeyIdx(deleteState.detachDeleteDirection)];
-    auto& reverseDirectedIndex = directedIndices[RelDirectionUtils::relDirectionToKeyIdx(
-        RelDirectionUtils::getOppositeDirection(deleteState.detachDeleteDirection))];
     std::vector<std::pair<DirectedCSRIndex&, ValueVector&>> directedIndicesAndNodeIDVectors;
     auto directedIndexPos =
         RelDirectionUtils::relDirectionToKeyIdx(deleteState.detachDeleteDirection);
     if (directedIndexPos < directedIndices.size()) {
-        directedIndicesAndNodeIDVectors.emplace_back(directedIndex, deleteState.srcNodeIDVector);
+        directedIndicesAndNodeIDVectors.emplace_back(directedIndices[directedIndexPos],
+            deleteState.srcNodeIDVector);
     }
     auto reverseDirectedIndexPos = RelDirectionUtils::relDirectionToKeyIdx(
         RelDirectionUtils::getOppositeDirection(deleteState.detachDeleteDirection));
     if (reverseDirectedIndexPos < directedIndices.size()) {
-        directedIndicesAndNodeIDVectors.emplace_back(reverseDirectedIndex,
+        directedIndicesAndNodeIDVectors.emplace_back(directedIndices[reverseDirectedIndexPos],
             deleteState.dstNodeIDVector);
     }
     for (auto& [csrIndex, nodeIDVector] : directedIndicesAndNodeIDVectors) {

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -2267,4 +2267,51 @@ final class ConnectionTests: XCTestCase {
         XCTAssertTrue(results[1].distance < 0.5, "Second result should be close (updated B)")
         XCTAssertTrue(results[2].distance > 1.0, "Third result should be far (C=[0,0,1])")
     }
+
+    // MARK: - HNSW Bulk Insert with Shrink (Issue #66)
+
+    func testHNSWBulkInsertWithShrink() throws {
+        // This test exercises the shrinkForNode code path in HNSW index which calls
+        // detachDelete on FWD-only shadow rel tables. Before the fix, this would SIGABRT
+        // due to out-of-bounds access in LocalRelTable::delete_.
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        // Create table with 3-dim embedding
+        _ = try conn.query(
+            "CREATE NODE TABLE ShrinkTest(id INT64, embedding FLOAT[3], PRIMARY KEY(id))"
+        )
+
+        // Insert enough nodes to trigger shrinkForNode with small mu/ml
+        for i in 1...30 {
+            let x = Float(i) / 30.0
+            let y = Float(30 - i) / 30.0
+            let z = Float(i % 7) / 7.0
+            _ = try conn.query(
+                "CREATE (:ShrinkTest {id: \(i), embedding: [\(x), \(y), \(z)]})"
+            )
+        }
+
+        // Create HNSW index with small mu/ml to trigger shrink earlier
+        _ = try conn.query(
+            "CALL CREATE_VECTOR_INDEX('ShrinkTest', 'shrink_idx', 'embedding', metric := 'l2', mu := 4, ml := 4)"
+        )
+
+        // If we get here without SIGABRT, the fix works.
+        // Verify search still returns results.
+        let results = try conn.searchNearest(
+            table: "ShrinkTest", indexName: "shrink_idx",
+            queryVector: [1.0, 0.0, 0.0], k: 5
+        )
+        XCTAssertEqual(results.count, 5, "Should return 5 nearest neighbors")
+        XCTAssertTrue(results[0].distance <= results[1].distance, "Results should be sorted by distance")
+    }
 }


### PR DESCRIPTION
## Problem

SIGABRT crash in `LocalRelTable::delete_` when called from HNSW `shrinkForNode` on FWD-only rel tables.

HNSW shadow rel tables are created with `storage_direction='fwd'`, so `directedIndices` has only 1 element (index 0 = FWD). The `delete_` method created a reference to `directedIndices[reverseDirectedIndexPos]` BEFORE checking bounds, causing an out-of-bounds access when `reverseDirectedIndexPos = 1`.

## Fix

Removed the early `directedIndex` and `reverseDirectedIndex` reference declarations. Now `directedIndices[]` is accessed ONLY inside the bounds-checked `if` blocks.

## Test

Added `testHNSWBulkInsertWithShrink` that creates 30 nodes with a small mu/ml HNSW index to trigger the shrinkForNode code path. Before the fix this would SIGABRT; now all 87 ConnectionTests pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author