### PR TITLE
feat: add typed column access for FlatTuple and AsyncSequence for QueryResult

### DIFF
--- a/Sources/Kuzu/FlatTuple.swift
+++ b/Sources/Kuzu/FlatTuple.swift
@@ -81,4 +81,86 @@ public final class FlatTuple: CustomStringConvertible, @unchecked Sendable {
         }
         return result
     }
+
+    // MARK: - Typed Column Access
+
+    /// Type-safe value access with auto-conversion.
+    /// - Parameter index: Column index (0-based)
+    /// - Returns: Value cast to the requested type
+    /// - Throws: `KuzuError.getValueFailed` if type conversion fails or value is null
+    public func get<T>(_ index: UInt64) throws -> T {
+        guard let value = try getValue(index) else {
+            throw KuzuError.getValueFailed("Column \(index) is NULL")
+        }
+        if let result = value as? T {
+            return result
+        }
+        if let converted: T = Self.autoConvert(value) {
+            return converted
+        }
+        throw KuzuError.getValueFailed(
+            "Cannot convert column \(index) value of type \(type(of: value)) to \(T.self)"
+        )
+    }
+
+    /// Type-safe value access with explicit type parameter.
+    /// - Parameters:
+    ///   - index: Column index (0-based)
+    ///   - type: The target type to convert to
+    /// - Returns: Value cast to the requested type
+    /// - Throws: `KuzuError.getValueFailed` if type conversion fails or value is null
+    public func get<T>(_ index: UInt64, as type: T.Type) throws -> T {
+        return try get(index)
+    }
+
+    /// Nil-safe value access for nullable columns.
+    /// - Parameter index: Column index (0-based)
+    /// - Returns: Value cast to the requested type, or nil if the value is null or conversion fails
+    public func getOptional<T>(_ index: UInt64) -> T? {
+        guard let value = try? getValue(index) else { return nil }
+        if let result = value as? T { return result }
+        return Self.autoConvert(value)
+    }
+
+    /// Type-safe value access by column name.
+    /// - Parameter columnName: The column name (e.g. "n.name")
+    /// - Returns: Value cast to the requested type
+    /// - Throws: `KuzuError.getValueFailed` if column not found, type conversion fails, or value is null
+    public func get<T>(_ columnName: String) throws -> T {
+        let names = queryResult.getColumnNames()
+        guard let index = names.firstIndex(of: columnName) else {
+            throw KuzuError.getValueFailed("Column '\(columnName)' not found")
+        }
+        return try get(UInt64(index))
+    }
+
+    /// Nil-safe value access by column name.
+    /// - Parameter columnName: The column name (e.g. "n.name")
+    /// - Returns: Value cast to the requested type, or nil if column not found, value is null, or conversion fails
+    public func getOptional<T>(_ columnName: String) -> T? {
+        let names = queryResult.getColumnNames()
+        guard let index = names.firstIndex(of: columnName) else { return nil }
+        return getOptional(UInt64(index))
+    }
+
+    /// Auto-converts common numeric types.
+    private static func autoConvert<T>(_ value: Any) -> T? {
+        if T.self == Int.self {
+            if let v = value as? Int64 { return Int(v) as? T }
+            if let v = value as? Int32 { return Int(v) as? T }
+            if let v = value as? Int16 { return Int(v) as? T }
+            if let v = value as? Int8 { return Int(v) as? T }
+            if let v = value as? UInt64 { return Int(v) as? T }
+        }
+        if T.self == Double.self {
+            if let v = value as? Float { return Double(v) as? T }
+        }
+        if T.self == Float.self {
+            if let v = value as? Double { return Float(v) as? T }
+        }
+        if T.self == String.self {
+            return "\(value)" as? T
+        }
+        return nil
+    }
 }

--- a/Sources/Kuzu/QueryResult.swift
+++ b/Sources/Kuzu/QueryResult.swift
@@ -200,4 +200,45 @@ public final class QueryResult: CustomStringConvertible, Sequence, @unchecked
         kuzu_query_result_get_query_summary(&cQueryResult, &cQuerySummary)
         return kuzu_query_summary_get_execution_time(&cQuerySummary)
     }
+
+    /// Returns an AsyncSequence wrapper for async iteration.
+    ///
+    /// Usage:
+    /// ```swift
+    /// for try await row in result.async {
+    ///     let name: String = try row.get(0)
+    /// }
+    /// ```
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public var async: AsyncQueryResultSequence {
+        return AsyncQueryResultSequence(self)
+    }
+}
+
+/// AsyncSequence wrapper for QueryResult, enabling `for try await` iteration.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public struct AsyncQueryResultSequence: AsyncSequence {
+    public typealias Element = FlatTuple
+
+    private let queryResult: QueryResult
+
+    init(_ queryResult: QueryResult) {
+        self.queryResult = queryResult
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        return AsyncIterator(queryResult)
+    }
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        private let queryResult: QueryResult
+
+        init(_ queryResult: QueryResult) {
+            self.queryResult = queryResult
+        }
+
+        public mutating func next() async throws -> FlatTuple? {
+            return try queryResult.getNext()
+        }
+    }
 }

--- a/Tests/kuzu-swiftTests/ConnectionTests.swift
+++ b/Tests/kuzu-swiftTests/ConnectionTests.swift
@@ -2394,4 +2394,165 @@ final class ConnectionTests: XCTestCase {
         }
         XCTAssertEqual(names, ["Alice", "Charlie"], "Should return Alice and Charlie from IN clause")
     }
+
+    // MARK: - Typed Column Access Tests
+
+    func testTypedColumnAccess() throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        _ = try conn.query(
+            "CREATE NODE TABLE TypeTest(id INT64, name STRING, score DOUBLE, active BOOL, PRIMARY KEY(id))"
+        )
+        _ = try conn.query(
+            "CREATE (:TypeTest {id: 1, name: 'Alice', score: 95.5, active: true})"
+        )
+        _ = try conn.query(
+            "CREATE (:TypeTest {id: 2, name: 'Bob', score: 87.3, active: false})"
+        )
+
+        // Test for-in with typed get (Sequence already works)
+        let result = try conn.query(
+            "MATCH (n:TypeTest) RETURN n.id, n.name, n.score, n.active ORDER BY n.id"
+        )
+        var names: [String] = []
+        for row in result {
+            let name: String = try row.get(1)
+            names.append(name)
+        }
+        XCTAssertEqual(names, ["Alice", "Bob"])
+
+        // Test typed access on single row
+        let result2 = try conn.query(
+            "MATCH (n:TypeTest) WHERE n.id = 1 RETURN n.id, n.name, n.score, n.active"
+        )
+        let row = try result2.getNext()!
+
+        // Int64 → Int auto-conversion
+        let id: Int = try row.get(0)
+        XCTAssertEqual(id, 1)
+
+        let name: String = try row.get(1)
+        XCTAssertEqual(name, "Alice")
+
+        let score: Double = try row.get(2)
+        XCTAssertEqual(score, 95.5)
+
+        let active: Bool = try row.get(3)
+        XCTAssertTrue(active)
+
+        // Test get with explicit type parameter
+        let nameExplicit: String = try row.get(1, as: String.self)
+        XCTAssertEqual(nameExplicit, "Alice")
+
+        // Test get by column name
+        let nameByCol: String = try row.get("n.name")
+        XCTAssertEqual(nameByCol, "Alice")
+
+        // Test getOptional
+        let opt: String? = row.getOptional(1)
+        XCTAssertEqual(opt, "Alice")
+
+        // Test getOptional by column name
+        let optByCol: Double? = row.getOptional("n.score")
+        XCTAssertEqual(optByCol, 95.5)
+    }
+
+    func testTypedColumnAccessNull() throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        _ = try conn.query(
+            "CREATE NODE TABLE NullTest(id INT64, label STRING, PRIMARY KEY(id))"
+        )
+        _ = try conn.query("CREATE (:NullTest {id: 1})")  // label is NULL
+
+        let result = try conn.query("MATCH (n:NullTest) RETURN n.id, n.label")
+        let row = try result.getNext()!
+
+        // get<T> should throw for NULL
+        XCTAssertThrowsError(try { let _: String = try row.get(1) }())
+
+        // getOptional should return nil for NULL
+        let label: String? = row.getOptional(1)
+        XCTAssertNil(label)
+    }
+
+    func testTypedColumnAccessInvalidColumnName() throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        _ = try conn.query(
+            "CREATE NODE TABLE ColNameTest(id INT64, PRIMARY KEY(id))"
+        )
+        _ = try conn.query("CREATE (:ColNameTest {id: 1})")
+
+        let result = try conn.query("MATCH (n:ColNameTest) RETURN n.id")
+        let row = try result.getNext()!
+
+        // get by non-existent column name should throw
+        XCTAssertThrowsError(try { let _: Int = try row.get("nonexistent") }())
+
+        // getOptional by non-existent column name should return nil
+        let opt: Int? = row.getOptional("nonexistent")
+        XCTAssertNil(opt)
+    }
+
+    // MARK: - AsyncSequence Tests
+
+    @available(macOS 10.15, iOS 13.0, *)
+    func testAsyncSequence() async throws {
+        let systemConfig = SystemConfig(
+            bufferPoolSize: 256 * 1024 * 1024,
+            maxNumThreads: 4,
+            enableCompression: true,
+            readOnly: false,
+            autoCheckpoint: true,
+            checkpointThreshold: UInt64.max
+        )
+        let memDb = try Database(":memory:", systemConfig)
+        let conn = try Connection(memDb)
+
+        _ = try conn.query(
+            "CREATE NODE TABLE AsyncTest(id INT64, PRIMARY KEY(id))"
+        )
+        _ = try conn.query("CREATE (:AsyncTest {id: 1})")
+        _ = try conn.query("CREATE (:AsyncTest {id: 2})")
+        _ = try conn.query("CREATE (:AsyncTest {id: 3})")
+
+        let result = try conn.query(
+            "MATCH (n:AsyncTest) RETURN n.id ORDER BY n.id"
+        )
+
+        var ids: [Int] = []
+        for try await row in result.async {
+            let id: Int = try row.get(0)
+            ids.append(id)
+        }
+        XCTAssertEqual(ids, [1, 2, 3])
+    }
 }


### PR DESCRIPTION
## Summary

Implements typed column access for `FlatTuple` and `AsyncSequence` for `QueryResult` (Issue #48).

## Changes

### Typed Column Access (`FlatTuple`)

- `get<T>(_ index: UInt64) throws -> T` — Type-safe value access with auto-conversion for numeric types (Int64→Int, Float↔Double)
- `get<T>(_ index: UInt64, as type: T.Type) throws -> T` — Explicit type parameter variant
- `getOptional<T>(_ index: UInt64) -> T?` — Nil-safe access for nullable columns
- `get<T>(_ columnName: String) throws -> T` — Access by column name (e.g. `"n.name"`)
- `getOptional<T>(_ columnName: String) -> T?` — Nil-safe access by column name

### AsyncSequence (`QueryResult`)

- `result.async` property returns `AsyncQueryResultSequence` for `for try await` iteration
- Available on macOS 10.15+, iOS 13.0+

### Usage

```swift
let result = try conn.query("MATCH (n:Person) RETURN n.id, n.name, n.age")

// Typed access
for row in result {
    let id: Int = try row.get(0)
    let name: String = try row.get("n.name")
    let age: Int? = row.getOptional(2)
}

// Async iteration
for try await row in result.async {
    let name: String = try row.get(1)
}
```

## Tests

- `testTypedColumnAccess` — Tests get<T> with Int, String, Double, Bool; column name access; getOptional
- `testTypedColumnAccessNull` — Tests NULL handling (throws on get, returns nil on getOptional)
- `testTypedColumnAccessInvalidColumnName` — Tests error on non-existent column names
- `testAsyncSequence` — Tests `for try await` iteration

All 4 tests pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author