### PR TITLE
test: Memory stability & QPS benchmarks (1M queries)

### DIFF
--- a/Tests/kuzu-swiftTests/MemoryTests.swift
+++ b/Tests/kuzu-swiftTests/MemoryTests.swift
@@ -7,7 +7,7 @@ import Darwin
 
 final class MemoryTests: XCTestCase {
 
-    // MARK: - Memory Measurement Helper
+    // MARK: - Memory Measurement Helpers
 
     /// Returns current RSS (Resident Set Size) in MB
     static func currentRSSInMB() -> Double {
@@ -22,6 +22,63 @@ final class MemoryTests: XCTestCase {
         return Double(info.resident_size) / (1024 * 1024)
     }
 
+    /// Returns KuzuDB buffer manager memory usage in MB
+    static func kuzuMemoryUsageMB(_ conn: Connection) -> (limitMB: Double, usageMB: Double) {
+        do {
+            let result = try conn.query("CALL bm_info() RETURN mem_limit, mem_usage")
+            if result.hasNext(), let row = try result.getNext() {
+                let limit = try row.getValue(0) as! UInt64
+                let usage = try row.getValue(1) as! UInt64
+                return (Double(limit) / (1024 * 1024), Double(usage) / (1024 * 1024))
+            }
+        } catch {
+            print("[MemoryTest] Warning: Failed to get bm_info: \(error)")
+        }
+        return (-1, -1)
+    }
+
+    struct MemorySnapshot {
+        let queryCount: Int
+        let processRSSMB: Double
+        let kuzuUsageMB: Double
+        let kuzuLimitMB: Double
+
+        var nonKuzuMB: Double { processRSSMB - kuzuUsageMB }
+    }
+
+    static func captureSnapshot(_ conn: Connection, queryCount: Int) -> MemorySnapshot {
+        let rss = currentRSSInMB()
+        let (kuzuLimit, kuzuUsage) = kuzuMemoryUsageMB(conn)
+        return MemorySnapshot(queryCount: queryCount, processRSSMB: rss, kuzuUsageMB: kuzuUsage, kuzuLimitMB: kuzuLimit)
+    }
+
+    static func printSnapshot(_ snapshot: MemorySnapshot, label: String, prefix: String = "[MemoryTest]") {
+        print("\(prefix) \(label):")
+        print("\(prefix)   Process RSS:     \(String(format: "%.1f", snapshot.processRSSMB)) MB")
+        print("\(prefix)   KuzuDB usage:    \(String(format: "%.1f", snapshot.kuzuUsageMB)) MB / \(String(format: "%.1f", snapshot.kuzuLimitMB)) MB limit")
+        print("\(prefix)   Non-Kuzu:        \(String(format: "%.1f", snapshot.nonKuzuMB)) MB")
+    }
+
+    static func printDualAnalysis(_ first: MemorySnapshot, _ last: MemorySnapshot, prefix: String = "[MemoryTest]") {
+        let rssGrowth = last.processRSSMB - first.processRSSMB
+        let kuzuGrowth = last.kuzuUsageMB - first.kuzuUsageMB
+        let nonKuzuGrowth = last.nonKuzuMB - first.nonKuzuMB
+        print("\(prefix) === MEMORY ANALYSIS ===")
+        print("\(prefix) Process RSS growth:  \(String(format: "%+.1f", rssGrowth)) MB (\(String(format: "%.1f", first.processRSSMB)) → \(String(format: "%.1f", last.processRSSMB)))")
+        print("\(prefix) KuzuDB usage growth: \(String(format: "%+.1f", kuzuGrowth)) MB (\(String(format: "%.1f", first.kuzuUsageMB)) → \(String(format: "%.1f", last.kuzuUsageMB)))")
+        print("\(prefix) Non-Kuzu growth:     \(String(format: "%+.1f", nonKuzuGrowth)) MB (\(String(format: "%.1f", first.nonKuzuMB)) → \(String(format: "%.1f", last.nonKuzuMB)))")
+        print("\(prefix) KuzuDB buffer pool utilization: \(String(format: "%.1f", last.kuzuUsageMB / last.kuzuLimitMB * 100))% (\(String(format: "%.1f", last.kuzuUsageMB)) / \(String(format: "%.1f", last.kuzuLimitMB)) MB)")
+    }
+
+    static func printPerfSummary(totalQueries: Int, totalTime: Double, qpsValues: [Double], prefix: String = "[MemoryTest]") {
+        print("\(prefix) === PERFORMANCE SUMMARY ===")
+        print("\(prefix) Total queries: \(totalQueries)")
+        print("\(prefix) Total time: \(String(format: "%.1f", totalTime))s")
+        print("\(prefix) Average QPS: \(String(format: "%.0f", Double(totalQueries) / totalTime))")
+        print("\(prefix) Peak QPS: \(String(format: "%.0f", qpsValues.max() ?? 0))")
+        print("\(prefix) Min QPS: \(String(format: "%.0f", qpsValues.min() ?? 0))")
+    }
+
     // MARK: - Test 1: Memory stability during repeated INSERT queries
 
     func testMemoryStabilityDuringBatchInsert() throws {
@@ -30,16 +87,18 @@ final class MemoryTests: XCTestCase {
 
         _ = try conn.query("CREATE NODE TABLE MemNode(id INT64, name STRING, value DOUBLE, PRIMARY KEY(id))")
 
-        let totalQueries = 10_000
-        let measureInterval = 1000
+        let totalQueries = 1_000_000
+        let measureInterval = 100_000
         let stmt = try conn.prepare("CREATE (:MemNode {id: $id, name: $name, value: $val})")
 
-        var memorySnapshots: [(queryCount: Int, rssMB: Double)] = []
-        let baselineRSS = MemoryTests.currentRSSInMB()
-        memorySnapshots.append((0, baselineRSS))
-        print("[MemoryTest] Baseline RSS: \(String(format: "%.1f", baselineRSS)) MB")
+        var snapshots: [MemorySnapshot] = []
+        let baseline = MemoryTests.captureSnapshot(conn, queryCount: 0)
+        snapshots.append(baseline)
+        MemoryTests.printSnapshot(baseline, label: "Baseline")
 
         let startTime = Date()
+        var lastIntervalTime = startTime
+        var qpsValues: [Double] = []
 
         for i in 0..<totalQueries {
             _ = try conn.execute(stmt, [
@@ -49,30 +108,38 @@ final class MemoryTests: XCTestCase {
             ] as [String: Any?])
 
             if (i + 1) % measureInterval == 0 {
-                let rss = MemoryTests.currentRSSInMB()
-                let elapsed = Date().timeIntervalSince(startTime)
-                memorySnapshots.append((i + 1, rss))
-                print("[MemoryTest] After \(i + 1) inserts: RSS = \(String(format: "%.1f", rss)) MB, elapsed = \(String(format: "%.1f", elapsed))s")
+                let now = Date()
+                let elapsed = now.timeIntervalSince(startTime)
+                let intervalTime = now.timeIntervalSince(lastIntervalTime)
+                let intervalQPS = Double(measureInterval) / intervalTime
+                let avgQPS = Double(i + 1) / elapsed
+                qpsValues.append(intervalQPS)
+                lastIntervalTime = now
+
+                let snapshot = MemoryTests.captureSnapshot(conn, queryCount: i + 1)
+                snapshots.append(snapshot)
+                MemoryTests.printSnapshot(snapshot, label: "After \(i + 1) inserts")
+                print("[MemoryTest]   QPS:             \(String(format: "%.0f", intervalQPS)) queries/sec (last interval)")
+                print("[MemoryTest]   Avg QPS:         \(String(format: "%.0f", avgQPS)) queries/sec (cumulative)")
             }
         }
 
         // Checkpoint to flush WAL
         _ = try conn.query("CHECKPOINT")
-        let postCheckpointRSS = MemoryTests.currentRSSInMB()
-        print("[MemoryTest] Post-CHECKPOINT RSS: \(String(format: "%.1f", postCheckpointRSS)) MB")
+        let postCheckpoint = MemoryTests.captureSnapshot(conn, queryCount: totalQueries)
+        MemoryTests.printSnapshot(postCheckpoint, label: "Post-CHECKPOINT")
 
-        // Analysis: check if memory growth is bounded
-        let firstHalfGrowth = memorySnapshots[5].rssMB - memorySnapshots[1].rssMB  // 1K-5K
-        let secondHalfGrowth = memorySnapshots[9].rssMB - memorySnapshots[5].rssMB // 5K-10K
-        let totalGrowth = memorySnapshots.last!.rssMB - baselineRSS
+        // Analysis
+        let totalGrowth = snapshots.last!.processRSSMB - baseline.processRSSMB
+        let halfIdx = snapshots.count / 2
+        let firstHalfGrowth = snapshots[halfIdx].processRSSMB - snapshots[1].processRSSMB
+        let secondHalfGrowth = snapshots.last!.processRSSMB - snapshots[halfIdx].processRSSMB
 
-        print("[MemoryTest] === MEMORY ANALYSIS ===")
-        print("[MemoryTest] Total growth: \(String(format: "%.1f", totalGrowth)) MB")
-        print("[MemoryTest] First half growth (1K-5K): \(String(format: "%.1f", firstHalfGrowth)) MB")
-        print("[MemoryTest] Second half growth (5K-10K): \(String(format: "%.1f", secondHalfGrowth)) MB")
+        MemoryTests.printDualAnalysis(baseline, snapshots.last!)
+        MemoryTests.printPerfSummary(totalQueries: totalQueries, totalTime: Date().timeIntervalSince(startTime), qpsValues: qpsValues)
 
-        // PASS if: total growth < 200MB (reasonable for 10K rows)
-        XCTAssertLessThan(totalGrowth, 200.0, "Memory grew more than 200MB for 10K inserts — possible leak")
+        // PASS if: total growth < 500MB (reasonable for 1M rows)
+        XCTAssertLessThan(totalGrowth, 500.0, "Memory grew more than 500MB for 1M inserts — possible leak")
 
         if secondHalfGrowth > firstHalfGrowth * 2.0 && firstHalfGrowth > 5.0 {
             print("[MemoryTest] ⚠️ WARNING: Memory growth is accelerating — possible leak")
@@ -96,37 +163,47 @@ final class MemoryTests: XCTestCase {
         }
         _ = try conn.query("CHECKPOINT")
 
-        let totalQueries = 20_000
-        let measureInterval = 2000
+        let totalQueries = 1_000_000
+        let measureInterval = 100_000
 
-        var memorySnapshots: [(queryCount: Int, rssMB: Double)] = []
-        let baselineRSS = MemoryTests.currentRSSInMB()
-        memorySnapshots.append((0, baselineRSS))
-        print("[MemoryTest-Read] Baseline RSS: \(String(format: "%.1f", baselineRSS)) MB")
+        var snapshots: [MemorySnapshot] = []
+        let baseline = MemoryTests.captureSnapshot(conn, queryCount: 0)
+        snapshots.append(baseline)
+        MemoryTests.printSnapshot(baseline, label: "Baseline", prefix: "[MemoryTest-Read]")
 
         let startTime = Date()
+        var lastIntervalTime = startTime
+        var qpsValues: [Double] = []
 
         for i in 0..<totalQueries {
             let result = try conn.query("MATCH (n:ReadNode) WHERE n.id = \(i % 100) RETURN n.id, n.name")
-            // Consume result
             while result.hasNext() {
                 let _ = try result.getNext()
             }
 
             if (i + 1) % measureInterval == 0 {
-                let rss = MemoryTests.currentRSSInMB()
-                let elapsed = Date().timeIntervalSince(startTime)
-                memorySnapshots.append((i + 1, rss))
-                print("[MemoryTest-Read] After \(i + 1) reads: RSS = \(String(format: "%.1f", rss)) MB, elapsed = \(String(format: "%.1f", elapsed))s")
+                let now = Date()
+                let elapsed = now.timeIntervalSince(startTime)
+                let intervalTime = now.timeIntervalSince(lastIntervalTime)
+                let intervalQPS = Double(measureInterval) / intervalTime
+                let avgQPS = Double(i + 1) / elapsed
+                qpsValues.append(intervalQPS)
+                lastIntervalTime = now
+
+                let snapshot = MemoryTests.captureSnapshot(conn, queryCount: i + 1)
+                snapshots.append(snapshot)
+                MemoryTests.printSnapshot(snapshot, label: "After \(i + 1) reads", prefix: "[MemoryTest-Read]")
+                print("[MemoryTest-Read]   QPS:             \(String(format: "%.0f", intervalQPS)) queries/sec (last interval)")
+                print("[MemoryTest-Read]   Avg QPS:         \(String(format: "%.0f", avgQPS)) queries/sec (cumulative)")
             }
         }
 
-        let totalGrowth = memorySnapshots.last!.rssMB - baselineRSS
-        print("[MemoryTest-Read] === ANALYSIS ===")
-        print("[MemoryTest-Read] Total growth after \(totalQueries) read queries: \(String(format: "%.1f", totalGrowth)) MB")
+        let totalGrowth = snapshots.last!.processRSSMB - baseline.processRSSMB
+        MemoryTests.printDualAnalysis(baseline, snapshots.last!, prefix: "[MemoryTest-Read]")
+        MemoryTests.printPerfSummary(totalQueries: totalQueries, totalTime: Date().timeIntervalSince(startTime), qpsValues: qpsValues, prefix: "[MemoryTest-Read]")
 
         // Read queries should NOT grow memory significantly
-        XCTAssertLessThan(totalGrowth, 50.0, "Memory grew \(String(format: "%.1f", totalGrowth))MB after \(totalQueries) read queries — possible leak")
+        XCTAssertLessThan(totalGrowth, 100.0, "Memory grew \(String(format: "%.1f", totalGrowth))MB after \(totalQueries) read queries — possible leak")
         print("[MemoryTest-Read] ✅ Memory stable during repeated reads")
     }
 
@@ -154,16 +231,22 @@ final class MemoryTests: XCTestCase {
         }
         _ = try conn.query("CHECKPOINT")
 
+        let baseline = MemoryTests.captureSnapshot(conn, queryCount: 0)
+        MemoryTests.printSnapshot(baseline, label: "Baseline", prefix: "[PerfTest]")
+
         // Measure query latency over time
-        let totalBatches = 10
-        let queriesPerBatch = 500
+        let totalBatches = 20
+        let queriesPerBatch = 50_000
+        let totalQueries = totalBatches * queriesPerBatch
         var batchLatencies: [(batch: Int, avgMs: Double)] = []
+        var qpsValues: [Double] = []
 
         print("[PerfTest] === QUERY PERFORMANCE TEST ===")
         print("[PerfTest] Dataset: 1000 nodes, 5000 edges")
         print("[PerfTest] Running \(totalBatches) batches × \(queriesPerBatch) queries")
 
         let queryStmt = try conn.prepare("MATCH (a:PerfNode {id: $id})-[:PerfEdge]->(b:PerfNode) RETURN b.id, b.name LIMIT 10")
+        let startTime = Date()
 
         for batch in 0..<totalBatches {
             let batchStart = Date()
@@ -176,18 +259,32 @@ final class MemoryTests: XCTestCase {
                 }
             }
 
-            let batchMs = Date().timeIntervalSince(batchStart) * 1000
+            let batchTime = Date().timeIntervalSince(batchStart)
+            let batchMs = batchTime * 1000
             let avgMs = batchMs / Double(queriesPerBatch)
+            let batchQPS = Double(queriesPerBatch) / batchTime
             batchLatencies.append((batch + 1, avgMs))
-            print("[PerfTest] Batch \(batch + 1): avg \(String(format: "%.2f", avgMs))ms/query (total \(String(format: "%.0f", batchMs))ms)")
+            qpsValues.append(batchQPS)
+
+            let cumQPS = Double((batch + 1) * queriesPerBatch) / Date().timeIntervalSince(startTime)
+
+            let snapshot = MemoryTests.captureSnapshot(conn, queryCount: (batch + 1) * queriesPerBatch)
+            MemoryTests.printSnapshot(snapshot, label: "Batch \(batch + 1)", prefix: "[PerfTest]")
+            print("[PerfTest]   avg \(String(format: "%.2f", avgMs))ms/query")
+            print("[PerfTest]   QPS:             \(String(format: "%.0f", batchQPS)) queries/sec (last interval)")
+            print("[PerfTest]   Avg QPS:         \(String(format: "%.0f", cumQPS)) queries/sec (cumulative)")
         }
+
+        let lastSnapshot = MemoryTests.captureSnapshot(conn, queryCount: totalQueries)
 
         // Check: last batch should not be significantly slower than first
         let firstBatchAvg = batchLatencies[0].avgMs
         let lastBatchAvg = batchLatencies.last!.avgMs
         let degradation = lastBatchAvg / firstBatchAvg
 
-        print("[PerfTest] === ANALYSIS ===")
+        MemoryTests.printDualAnalysis(baseline, lastSnapshot, prefix: "[PerfTest]")
+        MemoryTests.printPerfSummary(totalQueries: totalQueries, totalTime: Date().timeIntervalSince(startTime), qpsValues: qpsValues, prefix: "[PerfTest]")
+
         print("[PerfTest] First batch: \(String(format: "%.2f", firstBatchAvg))ms/query")
         print("[PerfTest] Last batch: \(String(format: "%.2f", lastBatchAvg))ms/query")
         print("[PerfTest] Degradation ratio: \(String(format: "%.2f", degradation))x")
@@ -215,13 +312,13 @@ final class MemoryTests: XCTestCase {
             _ = try conn.query("CREATE NODE TABLE TempNode(id INT64, data STRING, PRIMARY KEY(id))")
 
             let stmt = try conn.prepare("CREATE (:TempNode {id: $id, data: $data})")
-            for i in 0..<5000 {
+            for i in 0..<50_000 {
                 _ = try conn.execute(stmt, ["id": Int64(i), "data": String(repeating: "x", count: 100)] as [String: Any?])
             }
             _ = try conn.query("CHECKPOINT")
 
-            let afterInsert = MemoryTests.currentRSSInMB()
-            print("[MemRelease] After 5K inserts: \(String(format: "%.1f", afterInsert)) MB")
+            let afterSnapshot = MemoryTests.captureSnapshot(conn, queryCount: 50_000)
+            MemoryTests.printSnapshot(afterSnapshot, label: "After 50K inserts", prefix: "[MemRelease]")
         }
         // DB and conn should be deallocated here
 
@@ -237,7 +334,10 @@ final class MemoryTests: XCTestCase {
             let result = try conn.query("MATCH (n:TempNode) RETURN COUNT(*)")
             let row = try result.getNext()!
             let count = try row.getValue(0) as! Int64
-            XCTAssertEqual(count, 5000)
+            XCTAssertEqual(count, 50_000)
+
+            let reopenSnapshot = MemoryTests.captureSnapshot(conn, queryCount: 0)
+            MemoryTests.printSnapshot(reopenSnapshot, label: "After reopen", prefix: "[MemRelease]")
             print("[MemRelease] Reopened, verified \(count) nodes ✅")
         }
 

--- a/Tests/kuzu-swiftTests/MemoryTests.swift
+++ b/Tests/kuzu-swiftTests/MemoryTests.swift
@@ -1,0 +1,249 @@
+import XCTest
+@testable import Kuzu
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+final class MemoryTests: XCTestCase {
+
+    // MARK: - Memory Measurement Helper
+
+    /// Returns current RSS (Resident Set Size) in MB
+    static func currentRSSInMB() -> Double {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return -1 }
+        return Double(info.resident_size) / (1024 * 1024)
+    }
+
+    // MARK: - Test 1: Memory stability during repeated INSERT queries
+
+    func testMemoryStabilityDuringBatchInsert() throws {
+        let db = try Database(":memory:", SystemConfig(bufferPoolSize: 256 * 1024 * 1024))
+        let conn = try Connection(db)
+
+        _ = try conn.query("CREATE NODE TABLE MemNode(id INT64, name STRING, value DOUBLE, PRIMARY KEY(id))")
+
+        let totalQueries = 10_000
+        let measureInterval = 1000
+        let stmt = try conn.prepare("CREATE (:MemNode {id: $id, name: $name, value: $val})")
+
+        var memorySnapshots: [(queryCount: Int, rssMB: Double)] = []
+        let baselineRSS = MemoryTests.currentRSSInMB()
+        memorySnapshots.append((0, baselineRSS))
+        print("[MemoryTest] Baseline RSS: \(String(format: "%.1f", baselineRSS)) MB")
+
+        let startTime = Date()
+
+        for i in 0..<totalQueries {
+            _ = try conn.execute(stmt, [
+                "id": Int64(i),
+                "name": "node_\(i)",
+                "val": Double(i) * 0.001,
+            ] as [String: Any?])
+
+            if (i + 1) % measureInterval == 0 {
+                let rss = MemoryTests.currentRSSInMB()
+                let elapsed = Date().timeIntervalSince(startTime)
+                memorySnapshots.append((i + 1, rss))
+                print("[MemoryTest] After \(i + 1) inserts: RSS = \(String(format: "%.1f", rss)) MB, elapsed = \(String(format: "%.1f", elapsed))s")
+            }
+        }
+
+        // Checkpoint to flush WAL
+        _ = try conn.query("CHECKPOINT")
+        let postCheckpointRSS = MemoryTests.currentRSSInMB()
+        print("[MemoryTest] Post-CHECKPOINT RSS: \(String(format: "%.1f", postCheckpointRSS)) MB")
+
+        // Analysis: check if memory growth is bounded
+        let firstHalfGrowth = memorySnapshots[5].rssMB - memorySnapshots[1].rssMB  // 1K-5K
+        let secondHalfGrowth = memorySnapshots[9].rssMB - memorySnapshots[5].rssMB // 5K-10K
+        let totalGrowth = memorySnapshots.last!.rssMB - baselineRSS
+
+        print("[MemoryTest] === MEMORY ANALYSIS ===")
+        print("[MemoryTest] Total growth: \(String(format: "%.1f", totalGrowth)) MB")
+        print("[MemoryTest] First half growth (1K-5K): \(String(format: "%.1f", firstHalfGrowth)) MB")
+        print("[MemoryTest] Second half growth (5K-10K): \(String(format: "%.1f", secondHalfGrowth)) MB")
+
+        // PASS if: total growth < 200MB (reasonable for 10K rows)
+        XCTAssertLessThan(totalGrowth, 200.0, "Memory grew more than 200MB for 10K inserts — possible leak")
+
+        if secondHalfGrowth > firstHalfGrowth * 2.0 && firstHalfGrowth > 5.0 {
+            print("[MemoryTest] ⚠️ WARNING: Memory growth is accelerating — possible leak")
+            print("[MemoryTest]   First half: +\(String(format: "%.1f", firstHalfGrowth)) MB")
+            print("[MemoryTest]   Second half: +\(String(format: "%.1f", secondHalfGrowth)) MB")
+        } else {
+            print("[MemoryTest] ✅ Memory growth is stable/bounded")
+        }
+    }
+
+    // MARK: - Test 2: Memory stability during repeated READ queries
+
+    func testMemoryStabilityDuringRepeatedReads() throws {
+        let db = try Database(":memory:", SystemConfig(bufferPoolSize: 256 * 1024 * 1024))
+        let conn = try Connection(db)
+
+        // Setup: create small dataset
+        _ = try conn.query("CREATE NODE TABLE ReadNode(id INT64, name STRING, PRIMARY KEY(id))")
+        for i in 0..<100 {
+            _ = try conn.query("CREATE (:ReadNode {id: \(i), name: 'node_\(i)'})")
+        }
+        _ = try conn.query("CHECKPOINT")
+
+        let totalQueries = 20_000
+        let measureInterval = 2000
+
+        var memorySnapshots: [(queryCount: Int, rssMB: Double)] = []
+        let baselineRSS = MemoryTests.currentRSSInMB()
+        memorySnapshots.append((0, baselineRSS))
+        print("[MemoryTest-Read] Baseline RSS: \(String(format: "%.1f", baselineRSS)) MB")
+
+        let startTime = Date()
+
+        for i in 0..<totalQueries {
+            let result = try conn.query("MATCH (n:ReadNode) WHERE n.id = \(i % 100) RETURN n.id, n.name")
+            // Consume result
+            while result.hasNext() {
+                let _ = try result.getNext()
+            }
+
+            if (i + 1) % measureInterval == 0 {
+                let rss = MemoryTests.currentRSSInMB()
+                let elapsed = Date().timeIntervalSince(startTime)
+                memorySnapshots.append((i + 1, rss))
+                print("[MemoryTest-Read] After \(i + 1) reads: RSS = \(String(format: "%.1f", rss)) MB, elapsed = \(String(format: "%.1f", elapsed))s")
+            }
+        }
+
+        let totalGrowth = memorySnapshots.last!.rssMB - baselineRSS
+        print("[MemoryTest-Read] === ANALYSIS ===")
+        print("[MemoryTest-Read] Total growth after \(totalQueries) read queries: \(String(format: "%.1f", totalGrowth)) MB")
+
+        // Read queries should NOT grow memory significantly
+        XCTAssertLessThan(totalGrowth, 50.0, "Memory grew \(String(format: "%.1f", totalGrowth))MB after \(totalQueries) read queries — possible leak")
+        print("[MemoryTest-Read] ✅ Memory stable during repeated reads")
+    }
+
+    // MARK: - Test 3: Query performance stability
+
+    func testQueryPerformanceStability() throws {
+        let db = try Database(":memory:", SystemConfig(bufferPoolSize: 256 * 1024 * 1024))
+        let conn = try Connection(db)
+
+        // Setup: medium dataset
+        _ = try conn.query("CREATE NODE TABLE PerfNode(id INT64, name STRING, score DOUBLE, PRIMARY KEY(id))")
+        _ = try conn.query("CREATE REL TABLE PerfEdge(FROM PerfNode TO PerfNode, weight DOUBLE)")
+
+        // Insert 1000 nodes
+        let insertStmt = try conn.prepare("CREATE (:PerfNode {id: $id, name: $name, score: $score})")
+        for i in 0..<1000 {
+            _ = try conn.execute(insertStmt, ["id": Int64(i), "name": "node_\(i)", "score": Double(i) * 0.1] as [String: Any?])
+        }
+
+        // Insert 5000 edges
+        for i in 0..<5000 {
+            let src = i % 1000
+            let dst = (i * 7 + 13) % 1000
+            _ = try conn.query("MATCH (a:PerfNode {id: \(src)}), (b:PerfNode {id: \(dst)}) CREATE (a)-[:PerfEdge {weight: \(Double(i) * 0.001)}]->(b)")
+        }
+        _ = try conn.query("CHECKPOINT")
+
+        // Measure query latency over time
+        let totalBatches = 10
+        let queriesPerBatch = 500
+        var batchLatencies: [(batch: Int, avgMs: Double)] = []
+
+        print("[PerfTest] === QUERY PERFORMANCE TEST ===")
+        print("[PerfTest] Dataset: 1000 nodes, 5000 edges")
+        print("[PerfTest] Running \(totalBatches) batches × \(queriesPerBatch) queries")
+
+        let queryStmt = try conn.prepare("MATCH (a:PerfNode {id: $id})-[:PerfEdge]->(b:PerfNode) RETURN b.id, b.name LIMIT 10")
+
+        for batch in 0..<totalBatches {
+            let batchStart = Date()
+
+            for q in 0..<queriesPerBatch {
+                let targetId = (batch * queriesPerBatch + q) % 1000
+                let result = try conn.execute(queryStmt, ["id": Int64(targetId)] as [String: Any?])
+                while result.hasNext() {
+                    let _ = try result.getNext()
+                }
+            }
+
+            let batchMs = Date().timeIntervalSince(batchStart) * 1000
+            let avgMs = batchMs / Double(queriesPerBatch)
+            batchLatencies.append((batch + 1, avgMs))
+            print("[PerfTest] Batch \(batch + 1): avg \(String(format: "%.2f", avgMs))ms/query (total \(String(format: "%.0f", batchMs))ms)")
+        }
+
+        // Check: last batch should not be significantly slower than first
+        let firstBatchAvg = batchLatencies[0].avgMs
+        let lastBatchAvg = batchLatencies.last!.avgMs
+        let degradation = lastBatchAvg / firstBatchAvg
+
+        print("[PerfTest] === ANALYSIS ===")
+        print("[PerfTest] First batch: \(String(format: "%.2f", firstBatchAvg))ms/query")
+        print("[PerfTest] Last batch: \(String(format: "%.2f", lastBatchAvg))ms/query")
+        print("[PerfTest] Degradation ratio: \(String(format: "%.2f", degradation))x")
+
+        // PASS if last batch is not more than 3x slower than first
+        XCTAssertLessThan(degradation, 3.0, "Query performance degraded \(String(format: "%.1f", degradation))x — possible memory/cache issue")
+        print("[PerfTest] ✅ Query performance stable")
+    }
+
+    // MARK: - Test 4: Memory after DB close and reopen
+
+    func testMemoryReleasedAfterDBClose() throws {
+        let tempDir = NSTemporaryDirectory() + "kuzu_memtest_" + UUID().uuidString
+        let dbPath = tempDir + "/db"
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let beforeOpen = MemoryTests.currentRSSInMB()
+        print("[MemRelease] Before DB open: \(String(format: "%.1f", beforeOpen)) MB")
+
+        // Open DB, insert data, close
+        do {
+            let db = try Database(dbPath, SystemConfig(bufferPoolSize: 128 * 1024 * 1024))
+            let conn = try Connection(db)
+            _ = try conn.query("CREATE NODE TABLE TempNode(id INT64, data STRING, PRIMARY KEY(id))")
+
+            let stmt = try conn.prepare("CREATE (:TempNode {id: $id, data: $data})")
+            for i in 0..<5000 {
+                _ = try conn.execute(stmt, ["id": Int64(i), "data": String(repeating: "x", count: 100)] as [String: Any?])
+            }
+            _ = try conn.query("CHECKPOINT")
+
+            let afterInsert = MemoryTests.currentRSSInMB()
+            print("[MemRelease] After 5K inserts: \(String(format: "%.1f", afterInsert)) MB")
+        }
+        // DB and conn should be deallocated here
+
+        // Give OS time to reclaim
+        Thread.sleep(forTimeInterval: 1.0)
+        let afterClose = MemoryTests.currentRSSInMB()
+        print("[MemRelease] After DB close + 1s: \(String(format: "%.1f", afterClose)) MB")
+
+        // Reopen with smaller buffer pool
+        do {
+            let db = try Database(dbPath, SystemConfig(bufferPoolSize: 64 * 1024 * 1024))
+            let conn = try Connection(db)
+            let result = try conn.query("MATCH (n:TempNode) RETURN COUNT(*)")
+            let row = try result.getNext()!
+            let count = try row.getValue(0) as! Int64
+            XCTAssertEqual(count, 5000)
+            print("[MemRelease] Reopened, verified \(count) nodes ✅")
+        }
+
+        let finalRSS = MemoryTests.currentRSSInMB()
+        print("[MemRelease] Final RSS: \(String(format: "%.1f", finalRSS)) MB")
+        print("[MemRelease] ✅ DB lifecycle complete")
+    }
+}
+


### PR DESCRIPTION
## Summary

Comprehensive memory and performance tests with 1M query scale.

### 4 Tests

| Test | Scale | What it measures |
|------|-------|------------------|
| `testMemoryStabilityDuringBatchInsert` | 1M inserts | RSS + KuzuDB `bm_info()` memory growth |
| `testMemoryStabilityDuringRepeatedReads` | 1M reads | Read-only memory leak detection |
| `testQueryPerformanceStability` | 1M graph queries | Latency degradation over time |
| `testMemoryReleasedAfterDBClose` | 50K inserts | Memory lifecycle on DB close/reopen |

### Dual Memory Metrics

Each measurement point reports:
- **Process RSS** (`mach_task_basic_info`)
- **KuzuDB instance** (`CALL bm_info()` → `mem_usage`)
- **Non-Kuzu** = RSS - KuzuDB

### QPS Tracking

Each interval reports:
- Interval QPS (queries/sec for this batch)
- Cumulative avg QPS
- Performance summary at end (avg/peak/min QPS)

### Note

These tests are designed for **manual execution** — they will take several minutes at 1M scale:
```bash
swift test --filter MemoryTests
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author