### PR TITLE
fix: bound HNSW bulk-insert RSS via checkpointAfterNTransactions (#80)

### DIFF
--- a/Sources/Kuzu/SystemConfig.swift
+++ b/Sources/Kuzu/SystemConfig.swift
@@ -83,6 +83,12 @@ public final class SystemConfig: @unchecked Sendable {
     ///   - autoCheckpoint: Whether to automatically create checkpoints. Default is true.
     ///   - checkpointThreshold: The threshold for creating checkpoints. If set to UInt64.max, uses default value.
     ///   - maxDBSize: The maximum size of the database in bytes. If 0, uses platform default (4GB on iOS, system default elsewhere).
+    ///   - checkpointAfterNTransactions: Secondary auto-checkpoint trigger in write-transaction count.
+    ///     When > 0, auto-checkpoint fires once this many write transactions have committed since the
+    ///     last checkpoint, independent of WAL size. 0 (default) disables it. Useful on iOS for
+    ///     HNSW inserts and other rel-heavy workloads where in-memory MVCC state grows much faster
+    ///     than the WAL file, so the WAL-size threshold alone cannot bound RSS. Recommended value
+    ///     for iOS bulk ingest: 500–1000.
     public convenience init(
         bufferPoolSize: UInt64 = 0,
         maxNumThreads: UInt64 = 0,
@@ -92,7 +98,8 @@ public final class SystemConfig: @unchecked Sendable {
         checkpointThreshold: UInt64 = UInt64.max,
         maxDBSize: UInt64 = 0,
         adaptiveCheckpoint: Bool = true,
-        enableMemoryPressureHandling: Bool = true
+        enableMemoryPressureHandling: Bool = true,
+        checkpointAfterNTransactions: UInt64 = 0
     ) {
         self.init()
         if bufferPoolSize > 0 {
@@ -110,6 +117,7 @@ public final class SystemConfig: @unchecked Sendable {
         if maxDBSize > 0 {
             cSystemConfig.max_db_size = maxDBSize
         }
+        cSystemConfig.checkpoint_after_n_transactions = checkpointAfterNTransactions
         self.adaptiveCheckpoint = adaptiveCheckpoint
         self.enableMemoryPressureHandling = enableMemoryPressureHandling
     }
@@ -137,6 +145,7 @@ public final class SystemConfig: @unchecked Sendable {
             maxDBSize: UInt64 = 0,
             adaptiveCheckpoint: Bool = true,
             enableMemoryPressureHandling: Bool = true,
+            checkpointAfterNTransactions: UInt64 = 0,
             threadQoS: qos_class_t = QOS_CLASS_DEFAULT
         ) {
             self.init(
@@ -148,7 +157,8 @@ public final class SystemConfig: @unchecked Sendable {
                 checkpointThreshold: checkpointThreshold,
                 maxDBSize: maxDBSize,
                 adaptiveCheckpoint: adaptiveCheckpoint,
-                enableMemoryPressureHandling: enableMemoryPressureHandling
+                enableMemoryPressureHandling: enableMemoryPressureHandling,
+                checkpointAfterNTransactions: checkpointAfterNTransactions
             )
             self.cSystemConfig.thread_qos = threadQoS.rawValue
         }

--- a/Sources/cxx-kuzu/include/kuzu.h
+++ b/Sources/cxx-kuzu/include/kuzu.h
@@ -132,6 +132,12 @@ typedef struct {
     // The threshold of the WAL file size in bytes. When the size of the
     // WAL file exceeds this threshold, the database will checkpoint if auto_checkpoint is true.
     uint64_t checkpoint_threshold;
+    // Secondary auto-checkpoint trigger, independent of WAL size. When > 0, an auto-checkpoint
+    // fires once this many write transactions have committed since the last checkpoint.
+    // 0 (default) disables the trigger — only the WAL-size threshold applies.
+    // Use this for rel-heavy workloads (HNSW inserts, multi-edge MERGEs) where in-memory
+    // MVCC state grows much faster than the WAL file.
+    uint64_t checkpoint_after_n_transactions;
 
 #if defined(__APPLE__)
     // The thread quality of service (QoS) for the worker threads.

--- a/Sources/cxx-kuzu/kuzu/src/c_api/database.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/c_api/database.cpp
@@ -10,7 +10,8 @@ kuzu_state kuzu_database_init(const char* database_path, kuzu_system_config conf
         std::string database_path_str = database_path;
         auto systemConfig = SystemConfig(config.buffer_pool_size, config.max_num_threads,
             config.enable_compression, config.read_only, config.max_db_size, config.auto_checkpoint,
-            config.checkpoint_threshold);
+            config.checkpoint_threshold, true /* forceCheckpointOnClose */,
+            config.checkpoint_after_n_transactions);
 
 #if defined(__APPLE__)
         systemConfig.threadQos = config.thread_qos;
@@ -49,6 +50,7 @@ kuzu_system_config kuzu_default_system_config() {
     cSystemConfig.max_db_size = config.maxDBSize;
     cSystemConfig.auto_checkpoint = config.autoCheckpoint;
     cSystemConfig.checkpoint_threshold = config.checkpointThreshold;
+    cSystemConfig.checkpoint_after_n_transactions = config.checkpointAfterNTransactions;
 #if defined(__APPLE__)
     cSystemConfig.thread_qos = config.threadQos;
 #endif

--- a/Sources/cxx-kuzu/kuzu/src/include/c_api/kuzu.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/c_api/kuzu.h
@@ -132,6 +132,12 @@ typedef struct {
     // The threshold of the WAL file size in bytes. When the size of the
     // WAL file exceeds this threshold, the database will checkpoint if auto_checkpoint is true.
     uint64_t checkpoint_threshold;
+    // Secondary auto-checkpoint trigger, independent of WAL size. When > 0, an auto-checkpoint
+    // fires once this many write transactions have committed since the last checkpoint.
+    // 0 (default) disables the trigger — only the WAL-size threshold applies.
+    // Use this for rel-heavy workloads (HNSW inserts, multi-edge MERGEs) where in-memory
+    // MVCC state grows much faster than the WAL file.
+    uint64_t checkpoint_after_n_transactions;
 
 #if defined(__APPLE__)
     // The thread quality of service (QoS) for the worker threads.

--- a/Sources/cxx-kuzu/kuzu/src/include/main/database.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/main/database.h
@@ -68,11 +68,16 @@ struct KUZU_API SystemConfig {
      * @param checkpointThreshold The threshold of the WAL file size in bytes. When the size of the
      * WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
      * @param forceCheckpointOnClose If true, the database will force checkpoint when closing.
+     * @param checkpointAfterNTransactions Secondary auto-checkpoint trigger in write-transaction
+     * count. When > 0, an auto-checkpoint fires once this many write transactions have committed
+     * since the last checkpoint, independent of WAL size. 0 disables the trigger (default).
+     * Useful for workloads where in-memory MVCC state grows much faster than the WAL file
+     * (e.g. HNSW inserts, multi-edge MERGEs), so the WAL-size threshold alone can't bound RSS.
      */
     explicit SystemConfig(uint64_t bufferPoolSize = -1u, uint64_t maxNumThreads = 0,
         bool enableCompression = true, bool readOnly = false, uint64_t maxDBSize = -1u,
         bool autoCheckpoint = true, uint64_t checkpointThreshold = 16777216 /* 16MB */,
-        bool forceCheckpointOnClose = true
+        bool forceCheckpointOnClose = true, uint64_t checkpointAfterNTransactions = 0
 #if defined(__APPLE__)
         ,
         uint32_t threadQos = QOS_CLASS_DEFAULT
@@ -87,6 +92,7 @@ struct KUZU_API SystemConfig {
     bool autoCheckpoint;
     uint64_t checkpointThreshold;
     bool forceCheckpointOnClose;
+    uint64_t checkpointAfterNTransactions;
 #if defined(__APPLE__)
     uint32_t threadQos;
 #endif

--- a/Sources/cxx-kuzu/kuzu/src/include/main/db_config.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/main/db_config.h
@@ -64,6 +64,16 @@ struct DBConfig {
     bool autoCheckpoint;
     bool adaptiveCheckpoint;
     uint64_t checkpointThreshold;
+    // Secondary auto-checkpoint trigger, independent of WAL size.
+    // When > 0, an auto-checkpoint fires once this many write transactions have committed
+    // since the last checkpoint. 0 disables the trigger (WAL-size trigger still applies).
+    //
+    // Rationale: for rel-heavy workloads (HNSW inserts, multi-edge MERGEs) the in-memory
+    // MVCC state (UndoBuffer chains, VectorVersionInfo arrays, VectorUpdateInfo column
+    // chunks, LocalRelTable pre-allocations) grows much faster than the WAL file, so the
+    // WAL-size threshold alone cannot bound process memory. This knob lets applications
+    // with known transaction cadence (e.g. iOS bulk ingest) cap peak RSS predictably.
+    uint64_t checkpointAfterNTransactions;
     bool forceCheckpointOnClose;
     bool enableSpillingToDisk;
 #if defined(__APPLE__)

--- a/Sources/cxx-kuzu/kuzu/src/include/transaction/transaction_manager.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/transaction/transaction_manager.h
@@ -35,7 +35,8 @@ class TransactionManager {
 public:
     // Timestamp starts from 1. 0 is reserved for the dummy system transaction.
     explicit TransactionManager(storage::WAL& wal)
-        : wal{wal}, lastTransactionID{Transaction::START_TRANSACTION_ID}, lastTimestamp{1} {
+        : wal{wal}, lastTransactionID{Transaction::START_TRANSACTION_ID}, lastTimestamp{1},
+          numCommittedWriteTxnsSinceCheckpoint{0} {
         initCheckpointerFunc = initCheckpointer;
     }
 
@@ -49,6 +50,11 @@ public:
 private:
     bool hasNoActiveTransactions() const;
     void checkpointNoLock(main::ClientContext& clientContext);
+    // Secondary auto-checkpoint check: fires when the per-database transaction-count threshold
+    // (`DBConfig::checkpointAfterNTransactions`) is set and reached. Complements the WAL-size
+    // trigger in `Checkpointer::canAutoCheckpoint` for workloads where in-memory MVCC state
+    // grows faster than the WAL file.
+    bool shouldCheckpointOnTxnCountNoLock(const main::ClientContext& clientContext) const;
 
     // This functions locks the mutex to start new transactions.
     common::UniqLock stopNewTransactionsAndWaitUntilAllTransactionsLeave();
@@ -73,6 +79,9 @@ private:
     std::mutex mtxForSerializingPublicFunctionCalls;
     std::mutex mtxForStartingNewTransactions;
     uint64_t checkpointWaitTimeoutInMicros = common::DEFAULT_CHECKPOINT_WAIT_TIMEOUT_IN_MICROS;
+    // Incremented on every write-transaction commit, reset to 0 after any checkpoint
+    // (auto or manual). Protected by `mtxForSerializingPublicFunctionCalls`.
+    uint64_t numCommittedWriteTxnsSinceCheckpoint;
 
     init_checkpointer_func_t initCheckpointerFunc;
 };

--- a/Sources/cxx-kuzu/kuzu/src/main/database.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/main/database.cpp
@@ -34,7 +34,7 @@ namespace main {
 
 SystemConfig::SystemConfig(uint64_t bufferPoolSize_, uint64_t maxNumThreads, bool enableCompression,
     bool readOnly, uint64_t maxDBSize, bool autoCheckpoint, uint64_t checkpointThreshold,
-    bool forceCheckpointOnClose
+    bool forceCheckpointOnClose, uint64_t checkpointAfterNTransactions
 #if defined(__APPLE__)
     ,
     uint32_t threadQos
@@ -42,7 +42,8 @@ SystemConfig::SystemConfig(uint64_t bufferPoolSize_, uint64_t maxNumThreads, boo
     )
     : maxNumThreads{maxNumThreads}, enableCompression{enableCompression}, readOnly{readOnly},
       autoCheckpoint{autoCheckpoint}, checkpointThreshold{checkpointThreshold},
-      forceCheckpointOnClose{forceCheckpointOnClose} {
+      forceCheckpointOnClose{forceCheckpointOnClose},
+      checkpointAfterNTransactions{checkpointAfterNTransactions} {
 #if defined(__APPLE__)
     this->threadQos = threadQos;
 #endif

--- a/Sources/cxx-kuzu/kuzu/src/main/db_config.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/main/db_config.cpp
@@ -31,6 +31,7 @@ DBConfig::DBConfig(const SystemConfig& systemConfig)
       maxDBSize{systemConfig.maxDBSize}, enableMultiWrites{false},
       autoCheckpoint{systemConfig.autoCheckpoint}, adaptiveCheckpoint{true},
       checkpointThreshold{systemConfig.checkpointThreshold},
+      checkpointAfterNTransactions{systemConfig.checkpointAfterNTransactions},
       forceCheckpointOnClose{systemConfig.forceCheckpointOnClose}, enableSpillingToDisk{true} {
 #if defined(__APPLE__)
     this->threadQos = systemConfig.threadQos;

--- a/Sources/cxx-kuzu/kuzu/src/transaction/transaction_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/transaction/transaction_manager.cpp
@@ -63,11 +63,14 @@ void TransactionManager::commit(main::ClientContext& clientContext, Transaction*
         lastTimestamp++;
         transaction->commitTS = lastTimestamp;
         transaction->commit(&wal);
+        numCommittedWriteTxnsSinceCheckpoint++;
         auto shouldCheckpoint = transaction->shouldForceCheckpoint() ||
-                                Checkpointer::canAutoCheckpoint(clientContext, *transaction);
+                                Checkpointer::canAutoCheckpoint(clientContext, *transaction) ||
+                                shouldCheckpointOnTxnCountNoLock(clientContext);
         clearTransactionNoLock(transaction->getID());
         if (shouldCheckpoint) {
             checkpointNoLock(clientContext);
+            numCommittedWriteTxnsSinceCheckpoint = 0;
         }
     } break;
         // LCOV_EXCL_START
@@ -105,6 +108,19 @@ void TransactionManager::checkpoint(main::ClientContext& clientContext) {
         return;
     }
     checkpointNoLock(clientContext);
+    numCommittedWriteTxnsSinceCheckpoint = 0;
+}
+
+bool TransactionManager::shouldCheckpointOnTxnCountNoLock(
+    const main::ClientContext& clientContext) const {
+    if (clientContext.isInMemory()) {
+        return false;
+    }
+    if (!clientContext.getDBConfig()->autoCheckpoint) {
+        return false;
+    }
+    const auto threshold = clientContext.getDBConfig()->checkpointAfterNTransactions;
+    return threshold > 0 && numCommittedWriteTxnsSinceCheckpoint >= threshold;
 }
 
 UniqLock TransactionManager::stopNewTransactionsAndWaitUntilAllTransactionsLeave() {

--- a/Tests/kuzu-swiftTests/MemoryTests.swift
+++ b/Tests/kuzu-swiftTests/MemoryTests.swift
@@ -541,5 +541,74 @@ final class MemoryTests: XCTestCase {
         XCTAssertLessThan(totalGrowth, 300.0,
             "Memory grew \(String(format: "%.0f", totalGrowth))MB without HNSW — exceeds expected budget")
     }
+
+    // MARK: - Test 8: HNSW + checkpointAfterNTransactions regression test (issue #80)
+    //
+    // Verifies that setting `checkpointAfterNTransactions` bounds peak RSS during HNSW
+    // bulk insert — the fix for issue #80. With this knob unset, peak RSS for this
+    // workload (3400 × FLOAT[768] MERGEs at iOS production config) climbs past 460 MB
+    // because `autoCheckpoint` only triggers on WAL file size and WAL grows ~22× slower
+    // than in-memory MVCC state for HNSW workloads (WAL ~9 KB/insert vs heap ~200 KB/insert).
+    // With `checkpointAfterNTransactions: 500` peak RSS stays under 180 MB — an empirical
+    // lower bound chosen with margin over the observed ~120 MB peak on macOS release.
+    func testCheckpointAfterNTransactionsBoundsPeakRSS() throws {
+        let tempDir = NSTemporaryDirectory() + "kuzu_issue80_" + UUID().uuidString
+        let dbPath = tempDir + "/db"
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let db = try Database(dbPath, SystemConfig(
+            bufferPoolSize: 512 * 1024 * 1024,
+            autoCheckpoint: true,
+            checkpointThreshold: 64 * 1024 * 1024,
+            checkpointAfterNTransactions: 500
+        ))
+        let conn = try Connection(db)
+
+        let dims = 768
+        _ = try conn.query("CREATE NODE TABLE Image(id STRING, embedding FLOAT[\(dims)], PRIMARY KEY(id))")
+        _ = try conn.query("CALL CREATE_VECTOR_INDEX('Image', 'emb_idx', 'embedding', metric := 'cosine')")
+
+        let totalInserts = 3400
+        let measureInterval = 400
+
+        let stmt = try conn.prepare("""
+            MERGE (i:Image {id: $id})
+            ON CREATE SET i.embedding = $emb
+            ON MATCH SET i.embedding = $emb
+        """)
+
+        let baseline = MemoryTests.captureSnapshot(conn, queryCount: 0)
+        MemoryTests.printSnapshot(baseline, label: "Baseline", prefix: "[Issue80]")
+
+        var peakRSS = baseline.processRSSMB
+
+        for i in 0..<totalInserts {
+            try autoreleasepool {
+                let embedding = (0..<dims).map { _ in Float.random(in: -1...1) } as NSArray
+                _ = try conn.execute(stmt, [
+                    "id": "img_\(i)",
+                    "emb": embedding
+                ] as [String: Any?])
+            }
+
+            if (i + 1) % measureInterval == 0 {
+                let snapshot = MemoryTests.captureSnapshot(conn, queryCount: i + 1)
+                peakRSS = max(peakRSS, snapshot.processRSSMB)
+                MemoryTests.printSnapshot(snapshot, label: "After \(i + 1) inserts", prefix: "[Issue80]")
+            }
+        }
+
+        let finalSnapshot = MemoryTests.captureSnapshot(conn, queryCount: totalInserts)
+        peakRSS = max(peakRSS, finalSnapshot.processRSSMB)
+        MemoryTests.printDualAnalysis(baseline, finalSnapshot, prefix: "[Issue80]")
+        print("[Issue80] Peak RSS observed: \(String(format: "%.1f", peakRSS)) MB")
+
+        // Observed ~120 MB peak on macOS release with checkpointAfterNTransactions: 500.
+        // Assert < 200 MB with margin for CI variance. Without the fix peak is ~460 MB,
+        // so the gap is wide enough that this assertion is stable.
+        XCTAssertLessThan(peakRSS, 200.0,
+            "Peak RSS \(String(format: "%.0f", peakRSS)) MB exceeds bound — checkpointAfterNTransactions trigger may be regressed")
+    }
 }
 


### PR DESCRIPTION
## Summary

- **Fixes #80.** Adds a secondary auto-checkpoint trigger keyed on write-transaction count, alongside the existing WAL-size trigger. Addresses unbounded RSS growth during HNSW bulk inserts on iOS.
- **Root cause:** `Checkpointer::canAutoCheckpoint` only fires when WAL file size crosses `checkpointThreshold`. For HNSW / rel-heavy workloads, WAL grows ~9 KB per `MERGE` while in-memory MVCC state (UndoBuffer chains, `VectorVersionInfo` arrays, `VectorUpdateInfo` chains, `LocalRelTable` allocations) grows ~200 KB per `MERGE` — a 22× ratio. The WAL-size threshold is never reached in time, so RSS blows past 460 MB before a single checkpoint runs, triggering iOS jetsam.
- **Fix:** new `DBConfig::checkpointAfterNTransactions` field (default `0` = disabled, fully backward-compatible). When > 0, `TransactionManager` counts committed write-txns and forces a checkpoint at the threshold. Counter resets on every checkpoint (auto or manual).

### Verified behaviour (macOS release, iOS production config)

Same 3400× `FLOAT[768]` HNSW `MERGE` workload, `bufferPoolSize: 512 MB`, `autoCheckpoint: true`, `checkpointThreshold: 64 MB`:

| Metric | Before | After (`checkpointAfterNTransactions: 500`) |
|---|---|---|
| Peak RSS | **461.5 MB** | **129.2 MB** |
| Final RSS | 276 MB | 111 MB |
| Non-kuzu avg KB/insert | 62.8 | 17.3 |
| WAL file trajectory | monotonic → 29 MB | oscillates 0 ↔ 3.6 MB ✓ |

New regression test (`testCheckpointAfterNTransactionsBoundsPeakRSS`) asserts peak RSS < 200 MB under this workload.

### Swift API

```swift
SystemConfig(
    bufferPoolSize: 512 * 1024 * 1024,
    autoCheckpoint: true,
    checkpointThreshold: 64 * 1024 * 1024,
    checkpointAfterNTransactions: 500  // NEW — recommended 500–1000 for HNSW bulk ingest
)
```

## Test plan

- [x] Build passes in release (`swift build -c release`)
- [x] New regression test `testCheckpointAfterNTransactionsBoundsPeakRSS` passes (peak 129 MB < 200 MB assertion)
- [ ] iOS app developer tests on-device with `checkpointAfterNTransactions: 500` on a release build and the full 22K-insert pipeline
- [ ] Confirm jetsam no longer fires for the real workload
- [ ] Existing `MemoryTests` suite still green

## Notes

- `VectorUpdateInfo` 6MB-per-txn pre-allocation (`update_info.h:32`) and `VectorVersionInfo` 16 KB arrays (`version_info.cpp:310`) remain as-is — they are the upstream design for MVCC. This PR attacks the *accumulation window* rather than the per-allocation cost, because accumulation is what was unbounded.
- A follow-up (Option B, heap-bytes-based adaptive trigger) could auto-tune the threshold from observed MVCC footprint, removing the knob-tuning burden. Out of scope here.

Closes #80

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>