### PR TITLE
debug: add targeted probes for issue #83 HNSW checkpoint assertion

### DIFF
--- a/Sources/cxx-kuzu/kuzu/extension/vector/src/index/hnsw_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/vector/src/index/hnsw_index.cpp
@@ -739,8 +739,33 @@ void OnDiskHNSWIndex::checkpoint(main::ClientContext* context,
     storage::PageAllocator& pageAllocator) {
     auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] = getIndexTableCatalogEntries(
         context->getCatalog(), &DUMMY_CHECKPOINT_TRANSACTION, indexInfo);
-    upperRelTable->checkpoint(context, upperRelTableEntry, pageAllocator);
-    lowerRelTable->checkpoint(context, lowerRelTableEntry, pageAllocator);
+    // [DEBUG issue #83] Log HNSW sub-table checkpoint boundaries.
+    fprintf(stderr, "[KU83-HNSW] OnDiskHNSWIndex::checkpoint ENTRY indexName=%s\n",
+        indexInfo.name.c_str());
+    try {
+        fprintf(stderr, "[KU83-HNSW]   upperRelTable checkpoint begin name=%s\n",
+            upperRelTableEntry->getName().c_str());
+        upperRelTable->checkpoint(context, upperRelTableEntry, pageAllocator);
+        fprintf(stderr, "[KU83-HNSW]   upperRelTable checkpoint  done name=%s OK\n",
+            upperRelTableEntry->getName().c_str());
+    } catch (std::exception& e) {
+        fprintf(stderr, "[KU83-HNSW]   upperRelTable checkpoint FAIL name=%s err=%s\n",
+            upperRelTableEntry->getName().c_str(), e.what());
+        throw;
+    }
+    try {
+        fprintf(stderr, "[KU83-HNSW]   lowerRelTable checkpoint begin name=%s\n",
+            lowerRelTableEntry->getName().c_str());
+        lowerRelTable->checkpoint(context, lowerRelTableEntry, pageAllocator);
+        fprintf(stderr, "[KU83-HNSW]   lowerRelTable checkpoint  done name=%s OK\n",
+            lowerRelTableEntry->getName().c_str());
+    } catch (std::exception& e) {
+        fprintf(stderr, "[KU83-HNSW]   lowerRelTable checkpoint FAIL name=%s err=%s\n",
+            lowerRelTableEntry->getName().c_str(), e.what());
+        throw;
+    }
+    fprintf(stderr, "[KU83-HNSW] OnDiskHNSWIndex::checkpoint EXIT indexName=%s\n",
+        indexInfo.name.c_str());
 }
 
 void OnDiskHNSWIndex::insertInternal(Transaction* transaction, common::offset_t offset,

--- a/Sources/cxx-kuzu/kuzu/src/storage/compression/compression.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/compression/compression.cpp
@@ -647,6 +647,33 @@ void IntegerBitpacking<T>::setValuesFromUncompressed(const uint8_t* srcBuffer, o
     // non-zero offset However we don't care about the value stored for null values
     // Currently they will be mangled by storage+recovery (underflow in the subtraction
     // below)
+    // [DEBUG issue #83] Before asserting, identify and log the first value that can't fit.
+    {
+        offset_t firstBadIdx = posInSrc + numValues;
+        int64_t firstBadVal = 0;
+        offset_t badCount = 0;
+        for (offset_t i = posInSrc; i < posInSrc + numValues; ++i) {
+            auto value = reinterpret_cast<const T*>(srcBuffer)[i];
+            bool isNull = (nullMask && nullMask->isNull(i));
+            bool fits = isNull || canUpdateInPlace(std::span(&value, 1), metadata);
+            if (!fits) {
+                ++badCount;
+                if (firstBadIdx == posInSrc + numValues) {
+                    firstBadIdx = i;
+                    firstBadVal = (int64_t)value;
+                }
+            }
+        }
+        if (badCount != 0) {
+            fprintf(stderr,
+                "[KU83-COMPRESS] in-place update will FAIL: type=%s numValues=%llu posInSrc=%llu "
+                "badCount=%llu firstBadIdx=%llu firstBadVal=%lld posInDst=%llu\n",
+                typeid(T).name(),
+                (unsigned long long)numValues, (unsigned long long)posInSrc,
+                (unsigned long long)badCount, (unsigned long long)firstBadIdx,
+                (long long)firstBadVal, (unsigned long long)posInDst);
+        }
+    }
     KU_ASSERT(numValues == static_cast<offset_t>(std::ranges::count_if(
                                std::ranges::iota_view{posInSrc, posInSrc + numValues},
                                [srcBuffer, &metadata, nullMask](offset_t i) {

--- a/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
@@ -160,13 +160,27 @@ bool StorageManager::checkpoint(main::ClientContext* context, PageAllocator& pag
     const auto nodeTableEntries = catalog->getNodeTableEntries(&DUMMY_CHECKPOINT_TRANSACTION);
     const auto relGroupEntries = catalog->getRelGroupEntries(&DUMMY_CHECKPOINT_TRANSACTION);
 
+    // [DEBUG issue #83] Log checkpoint entry.
+    fprintf(stderr, "[KU83] StorageManager::checkpoint ENTRY  nodeTables=%zu relGroups=%zu\n",
+        nodeTableEntries.size(), relGroupEntries.size());
+
     for (const auto entry : nodeTableEntries) {
         if (!tables.contains(entry->getTableID())) {
             throw RuntimeException(stringFormat(
                 "Checkpoint failed: table {} not found in storage manager.", entry->getName()));
         }
-        hasChanges =
-            tables.at(entry->getTableID())->checkpoint(context, entry, pageAllocator) || hasChanges;
+        fprintf(stderr, "[KU83]   node table begin: name=%s tableID=%llu\n",
+            entry->getName().c_str(), (unsigned long long)entry->getTableID());
+        try {
+            hasChanges =
+                tables.at(entry->getTableID())->checkpoint(context, entry, pageAllocator) || hasChanges;
+            fprintf(stderr, "[KU83]   node table  done: name=%s tableID=%llu OK\n",
+                entry->getName().c_str(), (unsigned long long)entry->getTableID());
+        } catch (std::exception& e) {
+            fprintf(stderr, "[KU83]   node table FAIL: name=%s tableID=%llu err=%s\n",
+                entry->getName().c_str(), (unsigned long long)entry->getTableID(), e.what());
+            throw;
+        }
     }
     for (const auto entry : relGroupEntries) {
         for (auto& info : entry->getRelEntryInfos()) {
@@ -174,12 +188,23 @@ bool StorageManager::checkpoint(main::ClientContext* context, PageAllocator& pag
                 throw RuntimeException(stringFormat(
                     "Checkpoint failed: table {} not found in storage manager.", entry->getName()));
             }
-            hasChanges =
-                tables.at(info.oid)->checkpoint(context, entry, pageAllocator) || hasChanges;
+            fprintf(stderr, "[KU83]   rel  table begin: group=%s oid=%llu\n",
+                entry->getName().c_str(), (unsigned long long)info.oid);
+            try {
+                hasChanges =
+                    tables.at(info.oid)->checkpoint(context, entry, pageAllocator) || hasChanges;
+                fprintf(stderr, "[KU83]   rel  table  done: group=%s oid=%llu OK\n",
+                    entry->getName().c_str(), (unsigned long long)info.oid);
+            } catch (std::exception& e) {
+                fprintf(stderr, "[KU83]   rel  table FAIL: group=%s oid=%llu err=%s\n",
+                    entry->getName().c_str(), (unsigned long long)info.oid, e.what());
+                throw;
+            }
         }
         entry->vacuumColumnIDs(1);
     }
     reclaimDroppedTables(*catalog);
+    fprintf(stderr, "[KU83] StorageManager::checkpoint EXIT  hasChanges=%d\n", (int)hasChanges);
     return hasChanges;
 }
 

--- a/Sources/cxx-kuzu/kuzu/src/storage/table/node_group.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/table/node_group.cpp
@@ -634,7 +634,23 @@ std::unique_ptr<ChunkedNodeGroup> NodeGroup::scanAllInsertedAndVersions(
     }
     for (auto i = 0u; i < columnIDs.size(); i++) {
         if (columnIDs[i] != 0) {
-            KU_ASSERT(numResidentRows == mergedInMemGroup->getColumnChunk(i).getNumValues());
+            // [DEBUG issue #83] Log per-column value counts before the invariant check.
+            const auto gotValues = mergedInMemGroup->getColumnChunk(i).getNumValues();
+            if (numResidentRows != gotValues) {
+                fprintf(stderr,
+                    "[KU83-MERGE] column drift at scanAllInsertedAndVersions: "
+                    "colIdx=%u columnID=%u expectedRows=%llu gotValues=%llu totalCols=%zu\n",
+                    i, columnIDs[i],
+                    (unsigned long long)numResidentRows, (unsigned long long)gotValues,
+                    columnIDs.size());
+                // Dump every column's actual count to see the full drift pattern.
+                for (auto j = 0u; j < columnIDs.size(); j++) {
+                    fprintf(stderr, "[KU83-MERGE]   col j=%u colID=%u numValues=%llu\n",
+                        j, columnIDs[j],
+                        (unsigned long long)mergedInMemGroup->getColumnChunk(j).getNumValues());
+                }
+            }
+            KU_ASSERT(numResidentRows == gotValues);
         }
     }
     mergedInMemGroup->setNumRows(numResidentRows);


### PR DESCRIPTION
## Summary

Adds 4 `fprintf` probes (stderr, `[KU83...]` prefixed) to pinpoint the `compression.cpp:656` and `node_group.cpp:637` assertions that trip on first manual checkpoint for the iOS HNSW workload (#83).

Merging this into main since this is our fork and having the probes always-on helps when the iOS developer retests — no branch-switching friction. Will remove the probes in the same PR that lands the actual #83 fix.

## Probe points

- **`StorageManager::checkpoint`** (`src/storage/storage_manager.cpp`) — logs every node/rel table checkpoint begin/done/fail with name + OID. Runs on every checkpoint.
- **`OnDiskHNSWIndex::checkpoint`** (`extension/vector/src/index/hnsw_index.cpp`) — logs upper- and lower-rel-table checkpoint boundaries separately. Runs on every HNSW index checkpoint.
- **`compression.cpp:656`** (`IntegerBitpacking::setValuesFromUncompressed`) — only prints on failure (scans for first bad value, logs type + numValues + firstBadIdx + firstBadVal + posInDst). Silent on success.
- **`node_group.cpp:637`** (`NodeGroup::scanAllInsertedAndVersions`) — only prints on drift (dumps every column's `numValues` for the whole merged chunk). Silent on success.

## Noise estimate

For the iOS pipeline at `checkpointAfterNTransactions: 500` + 22K inserts:
- ~44 checkpoints → ~44 × (2 StorageManager lines + N_tables × 3 + HNSW lines) ≈ ~500-1000 lines total
- 0 compression/drift lines if everything's OK; bursts only when #83 fires

## Test plan

- [x] `swift build -c release` passes
- [ ] iOS developer updates Package.resolved, runs F4 repro, captures `[KU83]` lines
- [ ] Feed log back into #83 to identify the specific failing table + value
- [ ] Ship fix + remove probes in a follow-up PR

Closes nothing — investigation infrastructure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)