### PR TITLE
debug: halt on first #83 probe hit to avoid cascading log spam

### DIFF
--- a/Sources/cxx-kuzu/kuzu/src/storage/compression/compression.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/compression/compression.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 #include <string>
 
@@ -672,6 +673,11 @@ void IntegerBitpacking<T>::setValuesFromUncompressed(const uint8_t* srcBuffer, o
                 (unsigned long long)numValues, (unsigned long long)posInSrc,
                 (unsigned long long)badCount, (unsigned long long)firstBadIdx,
                 (long long)firstBadVal, (unsigned long long)posInDst);
+            fflush(stderr);
+            // [DEBUG issue #83] Halt immediately so the first failure produces a single clean
+            // log capture. Without this, KU_ASSERT below throws and the app catches it, then
+            // retries checkpoint → cascades into node_group.cpp:637 repeatedly.
+            std::abort();
         }
     }
     KU_ASSERT(numValues == static_cast<offset_t>(std::ranges::count_if(

--- a/Sources/cxx-kuzu/kuzu/src/storage/table/node_group.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/table/node_group.cpp
@@ -1,5 +1,7 @@
 #include "storage/table/node_group.h"
 
+#include <cstdlib>
+
 #include "common/assert.h"
 #include "common/types/types.h"
 #include "common/uniq_lock.h"
@@ -649,6 +651,11 @@ std::unique_ptr<ChunkedNodeGroup> NodeGroup::scanAllInsertedAndVersions(
                         j, columnIDs[j],
                         (unsigned long long)mergedInMemGroup->getColumnChunk(j).getNumValues());
                 }
+                fflush(stderr);
+                // [DEBUG issue #83] Halt immediately so the first failure produces a single
+                // clean log capture. Without this, KU_ASSERT below throws and the app catches
+                // it, then retries checkpoint → cascades into repeated drift assertions.
+                std::abort();
             }
             KU_ASSERT(numResidentRows == gotValues);
         }


### PR DESCRIPTION
## Summary

Follow-up to #85. Adds `std::abort()` after the two failure-path probes so the process terminates on the very first assertion trip instead of letting the app catch the KuzuError and retry (which was cascading into hundreds of repeated `node_group.cpp:637` drift lines).

With this, the iOS repro produces a single clean log where the PRIMARY failure is the last `[KU83...]` line printed — much easier to read.

## Test plan

- [x] `swift build -c release` passes
- [ ] iOS developer pulls latest main, runs F4 repro on fresh install
- [ ] Expect: app terminates on first checkpoint failure, single `[KU83...]` log capture at top of crash

Probe infra from #85 stays intact; only behavior change is abort-on-failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)