### PR TITLE
feat: compile-time checkpoint diagnostic logging (KUZU_DEBUG_CHECKPOINT)

### DIFF
--- a/Sources/cxx-kuzu/kuzu/extension/vector/src/index/hnsw_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/vector/src/index/hnsw_index.cpp
@@ -2,6 +2,7 @@
 
 #include "catalog/catalog_entry/index_catalog_entry.h"
 #include "catalog/hnsw_index_catalog_entry.h"
+#include "common/debug_log.h"
 #include "function/hnsw_index_functions.h"
 #include "index/hnsw_rel_batch_insert.h"
 #include "main/client_context.h"
@@ -739,8 +740,30 @@ void OnDiskHNSWIndex::checkpoint(main::ClientContext* context,
     storage::PageAllocator& pageAllocator) {
     auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] = getIndexTableCatalogEntries(
         context->getCatalog(), &DUMMY_CHECKPOINT_TRANSACTION, indexInfo);
-    upperRelTable->checkpoint(context, upperRelTableEntry, pageAllocator);
-    lowerRelTable->checkpoint(context, lowerRelTableEntry, pageAllocator);
+    KUZU_CP_LOG("  OnDiskHNSWIndex::checkpoint ENTRY indexName=%s\n", indexInfo.name.c_str());
+    try {
+        KUZU_CP_LOG("    upperRelTable checkpoint begin name=%s\n",
+            upperRelTableEntry->getName().c_str());
+        upperRelTable->checkpoint(context, upperRelTableEntry, pageAllocator);
+        KUZU_CP_LOG("    upperRelTable checkpoint  done name=%s OK\n",
+            upperRelTableEntry->getName().c_str());
+    } catch (std::exception& e) {
+        KUZU_CP_LOG("    upperRelTable checkpoint FAIL name=%s err=%s\n",
+            upperRelTableEntry->getName().c_str(), e.what());
+        throw;
+    }
+    try {
+        KUZU_CP_LOG("    lowerRelTable checkpoint begin name=%s\n",
+            lowerRelTableEntry->getName().c_str());
+        lowerRelTable->checkpoint(context, lowerRelTableEntry, pageAllocator);
+        KUZU_CP_LOG("    lowerRelTable checkpoint  done name=%s OK\n",
+            lowerRelTableEntry->getName().c_str());
+    } catch (std::exception& e) {
+        KUZU_CP_LOG("    lowerRelTable checkpoint FAIL name=%s err=%s\n",
+            lowerRelTableEntry->getName().c_str(), e.what());
+        throw;
+    }
+    KUZU_CP_LOG("  OnDiskHNSWIndex::checkpoint EXIT indexName=%s\n", indexInfo.name.c_str());
 }
 
 void OnDiskHNSWIndex::insertInternal(Transaction* transaction, common::offset_t offset,

--- a/Sources/cxx-kuzu/kuzu/src/include/common/debug_log.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/common/debug_log.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// Opt-in, compile-time diagnostic logging for checkpoint-path observability.
+//
+// Enable with: -DKUZU_DEBUG_CHECKPOINT
+//   - SwiftPM CLI: `swift build -Xcc -DKUZU_DEBUG_CHECKPOINT`
+//   - SwiftPM test: `swift test  -Xcc -DKUZU_DEBUG_CHECKPOINT ...`
+//   - Xcode iOS app: Build Settings → Other C++ Flags → add `-DKUZU_DEBUG_CHECKPOINT`
+//
+// When disabled (default), KUZU_CP_LOG and KUZU_CP_LOGF expand to `((void)0)` —
+// the preprocessor strips the call entirely. Zero runtime cost, no branch,
+// no format-string decode. Format-string arguments are not evaluated either.
+//
+// Motivation: tracking down #83 required on-device fprintf probes at the
+// checkpoint boundary. Rather than ship those probes permanently (noisy) or
+// drop them entirely (and re-land them next time), gate them behind this flag
+// so iOS developers can flip it on when investigating and leave production
+// builds completely clean.
+//
+// Probe sites currently using this macro:
+//   - StorageManager::checkpoint        (per-table begin/done/fail)
+//   - OnDiskHNSWIndex::checkpoint       (HNSW sub-table boundaries)
+//   - Column::canCheckpointInPlace      (in-place vs out-of-place decision)
+//   - NodeGroup::scanAllInsertedAndVersions (column-count drift on assert)
+//   - IntegerBitpacking::setValuesFromUncompressed (bad-value dump on assert)
+//
+// Grep for `KUZU_CP_LOG` to audit every instrumented site.
+
+#ifdef KUZU_DEBUG_CHECKPOINT
+#include <cstdio>
+// Formatted log — prefixes every line with `[KU-CP] ` and flushes stderr so
+// the message is visible even if the process subsequently aborts.
+#define KUZU_CP_LOG(...)                                                                           \
+    do {                                                                                           \
+        std::fprintf(stderr, "[KU-CP] " __VA_ARGS__);                                              \
+        std::fflush(stderr);                                                                       \
+    } while (0)
+#else
+#define KUZU_CP_LOG(...) ((void)0)
+#endif

--- a/Sources/cxx-kuzu/kuzu/src/storage/compression/compression.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/compression/compression.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "common/assert.h"
+#include "common/debug_log.h"
 #include "common/exception/not_implemented.h"
 #include "common/exception/storage.h"
 #include "common/null_mask.h"
@@ -647,6 +648,35 @@ void IntegerBitpacking<T>::setValuesFromUncompressed(const uint8_t* srcBuffer, o
     // non-zero offset However we don't care about the value stored for null values
     // Currently they will be mangled by storage+recovery (underflow in the subtraction
     // below)
+#ifdef KUZU_DEBUG_CHECKPOINT
+    // When the invariant is about to fail, walk the batch and log the first value that
+    // doesn't fit the current compression metadata. No-op in production builds.
+    {
+        offset_t badCount = 0;
+        offset_t firstBadIdx = posInSrc + numValues;
+        int64_t firstBadVal = 0;
+        for (offset_t i = posInSrc; i < posInSrc + numValues; ++i) {
+            auto value = reinterpret_cast<const T*>(srcBuffer)[i];
+            const bool isNull = (nullMask && nullMask->isNull(i));
+            const bool fits = isNull || canUpdateInPlace(std::span(&value, 1), metadata);
+            if (!fits) {
+                ++badCount;
+                if (firstBadIdx == posInSrc + numValues) {
+                    firstBadIdx = i;
+                    firstBadVal = (int64_t)value;
+                }
+            }
+        }
+        if (badCount != 0) {
+            KUZU_CP_LOG("IntegerBitpacking::setValuesFromUncompressed in-place FAIL: "
+                        "type=%s numValues=%llu posInSrc=%llu posInDst=%llu badCount=%llu "
+                        "firstBadIdx=%llu firstBadVal=%lld\n",
+                typeid(T).name(), (unsigned long long)numValues, (unsigned long long)posInSrc,
+                (unsigned long long)posInDst, (unsigned long long)badCount,
+                (unsigned long long)firstBadIdx, (long long)firstBadVal);
+        }
+    }
+#endif
     KU_ASSERT(numValues == static_cast<offset_t>(std::ranges::count_if(
                                std::ranges::iota_view{posInSrc, posInSrc + numValues},
                                [srcBuffer, &metadata, nullMask](offset_t i) {

--- a/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
+#include "common/debug_log.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/in_mem_file_writer.h"
 #include "main/client_context.h"
@@ -160,13 +161,26 @@ bool StorageManager::checkpoint(main::ClientContext* context, PageAllocator& pag
     const auto nodeTableEntries = catalog->getNodeTableEntries(&DUMMY_CHECKPOINT_TRANSACTION);
     const auto relGroupEntries = catalog->getRelGroupEntries(&DUMMY_CHECKPOINT_TRANSACTION);
 
+    KUZU_CP_LOG("StorageManager::checkpoint ENTRY nodeTables=%zu relGroups=%zu\n",
+        nodeTableEntries.size(), relGroupEntries.size());
+
     for (const auto entry : nodeTableEntries) {
         if (!tables.contains(entry->getTableID())) {
             throw RuntimeException(stringFormat(
                 "Checkpoint failed: table {} not found in storage manager.", entry->getName()));
         }
-        hasChanges =
-            tables.at(entry->getTableID())->checkpoint(context, entry, pageAllocator) || hasChanges;
+        KUZU_CP_LOG("  node table begin name=%s tableID=%llu\n", entry->getName().c_str(),
+            (unsigned long long)entry->getTableID());
+        try {
+            hasChanges = tables.at(entry->getTableID())->checkpoint(context, entry, pageAllocator) ||
+                         hasChanges;
+            KUZU_CP_LOG("  node table  done name=%s tableID=%llu OK\n", entry->getName().c_str(),
+                (unsigned long long)entry->getTableID());
+        } catch (std::exception& e) {
+            KUZU_CP_LOG("  node table FAIL name=%s tableID=%llu err=%s\n",
+                entry->getName().c_str(), (unsigned long long)entry->getTableID(), e.what());
+            throw;
+        }
     }
     for (const auto entry : relGroupEntries) {
         for (auto& info : entry->getRelEntryInfos()) {
@@ -174,12 +188,23 @@ bool StorageManager::checkpoint(main::ClientContext* context, PageAllocator& pag
                 throw RuntimeException(stringFormat(
                     "Checkpoint failed: table {} not found in storage manager.", entry->getName()));
             }
-            hasChanges =
-                tables.at(info.oid)->checkpoint(context, entry, pageAllocator) || hasChanges;
+            KUZU_CP_LOG("  rel  table begin group=%s oid=%llu\n", entry->getName().c_str(),
+                (unsigned long long)info.oid);
+            try {
+                hasChanges =
+                    tables.at(info.oid)->checkpoint(context, entry, pageAllocator) || hasChanges;
+                KUZU_CP_LOG("  rel  table  done group=%s oid=%llu OK\n", entry->getName().c_str(),
+                    (unsigned long long)info.oid);
+            } catch (std::exception& e) {
+                KUZU_CP_LOG("  rel  table FAIL group=%s oid=%llu err=%s\n",
+                    entry->getName().c_str(), (unsigned long long)info.oid, e.what());
+                throw;
+            }
         }
         entry->vacuumColumnIDs(1);
     }
     reclaimDroppedTables(*catalog);
+    KUZU_CP_LOG("StorageManager::checkpoint EXIT hasChanges=%d\n", (int)hasChanges);
     return hasChanges;
 }
 

--- a/Sources/cxx-kuzu/kuzu/src/storage/table/column.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/table/column.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "common/assert.h"
+#include "common/debug_log.h"
 #include "common/null_mask.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
@@ -412,9 +413,13 @@ bool Column::canCheckpointInPlace(const ChunkState& state,
     const ColumnCheckpointState& checkpointState) {
     if (isEndOffsetOutOfPagesCapacity(checkpointState.persistentData.getMetadata(),
             checkpointState.endRowIdxToWrite)) {
+        KUZU_CP_LOG("    canCheckpointInPlace: NO (page capacity exceeded) compression=%d\n",
+            (int)state.metadata.compMeta.compression);
         return false;
     }
     if (checkpointState.persistentData.getMetadata().compMeta.canAlwaysUpdateInPlace()) {
+        KUZU_CP_LOG("    canCheckpointInPlace: YES (canAlwaysUpdateInPlace) compression=%d\n",
+            (int)state.metadata.compMeta.compression);
         return true;
     }
 
@@ -426,9 +431,15 @@ bool Column::canCheckpointInPlace(const ChunkState& state,
             !state.metadata.compMeta.canUpdateInPlace(chunkData->getData(), 0,
                 chunkData->getNumValues(), dataType.getPhysicalType(), localUpdateState,
                 chunkData->getNullMask())) {
+            KUZU_CP_LOG("    canCheckpointInPlace: NO (canUpdateInPlace false) compression=%d "
+                        "numValues=%llu physicalType=%d\n",
+                (int)state.metadata.compMeta.compression,
+                (unsigned long long)chunkData->getNumValues(), (int)dataType.getPhysicalType());
             return false;
         }
     }
+    KUZU_CP_LOG("    canCheckpointInPlace: YES compression=%d\n",
+        (int)state.metadata.compMeta.compression);
     return true;
 }
 

--- a/Sources/cxx-kuzu/kuzu/src/storage/table/node_group.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/table/node_group.cpp
@@ -1,6 +1,7 @@
 #include "storage/table/node_group.h"
 
 #include "common/assert.h"
+#include "common/debug_log.h"
 #include "common/types/types.h"
 #include "common/uniq_lock.h"
 #include "storage/buffer_manager/memory_manager.h"
@@ -634,7 +635,20 @@ std::unique_ptr<ChunkedNodeGroup> NodeGroup::scanAllInsertedAndVersions(
     }
     for (auto i = 0u; i < columnIDs.size(); i++) {
         if (columnIDs[i] != 0) {
-            KU_ASSERT(numResidentRows == mergedInMemGroup->getColumnChunk(i).getNumValues());
+            // When the invariant is about to fail, dump every column's value count so the
+            // log pinpoints which column drifted and by how much. No-op in production builds.
+            const auto gotValues = mergedInMemGroup->getColumnChunk(i).getNumValues();
+            if (numResidentRows != gotValues) {
+                KUZU_CP_LOG("scanAllInsertedAndVersions drift: colIdx=%u columnID=%u "
+                            "expectedRows=%llu gotValues=%llu totalCols=%zu\n",
+                    i, columnIDs[i], (unsigned long long)numResidentRows,
+                    (unsigned long long)gotValues, columnIDs.size());
+                for (auto j = 0u; j < columnIDs.size(); j++) {
+                    KUZU_CP_LOG("  col j=%u colID=%u numValues=%llu\n", j, columnIDs[j],
+                        (unsigned long long)mergedInMemGroup->getColumnChunk(j).getNumValues());
+                }
+            }
+            KU_ASSERT(numResidentRows == gotValues);
         }
     }
     mergedInMemGroup->setNumRows(numResidentRows);


### PR DESCRIPTION
## Summary

Closes #88. Adds `KUZU_CP_LOG(...)` — a compile-time-gated macro that instruments the five checkpoint-path sites that were decisive during the #83 investigation. Default **off** (zero production cost); enable with `-DKUZU_DEBUG_CHECKPOINT` when investigating.

## Why

The `[KU83...]` fprintf probes we shipped temporarily via #85 / #86 and removed again in #87 were by far the most productive tool while hunting #83: they pinpointed the failing table, the bad value, and the exact code path within one iOS run. Rather than land new probes every time a storage bug surfaces, this PR bakes the capability in permanently behind a compile-time flag so the next investigation starts with a one-line build flag.

## API

```cpp
// Sources/cxx-kuzu/kuzu/src/include/common/debug_log.h
#ifdef KUZU_DEBUG_CHECKPOINT
#define KUZU_CP_LOG(...)  fprintf(stderr, "[KU-CP] " __VA_ARGS__); fflush(stderr)
#else
#define KUZU_CP_LOG(...)  ((void)0)
#endif
```

## Enabling

**SwiftPM CLI:**
```bash
swift build -c release -Xcc -DKUZU_DEBUG_CHECKPOINT
swift test  -c release -Xcc -DKUZU_DEBUG_CHECKPOINT --filter ...
```

**Xcode iOS app:**
Build Settings → Other C++ Flags (Debug) → add `-DKUZU_DEBUG_CHECKPOINT`

## Instrumented sites

| Site | What it logs |
|---|---|
| `StorageManager::checkpoint` | Per-table begin/done/fail with name + OID |
| `OnDiskHNSWIndex::checkpoint` | Upper/lower rel-table checkpoint boundaries |
| `Column::canCheckpointInPlace` | In-place vs out-of-place decision + reason |
| `NodeGroup::scanAllInsertedAndVersions` | Per-column value counts on drift (before assert) |
| `IntegerBitpacking::setValuesFromUncompressed` | Type + first bad index + first bad value (before assert) |

`grep KUZU_CP_LOG` audits everything instrumented.

## Test plan

- [x] Default build clean: `swift build -c release` → no log lines in tests
- [x] Flag build clean: `swift build -c release -Xcc -DKUZU_DEBUG_CHECKPOINT`
- [x] Probe activation confirmed: running `testCheckpointAfterNTransactionsBoundsPeakRSS` with the flag emits `[KU-CP]` lines for every checkpoint transition
- [x] All instrumented assertion-adjacent probes are inside existing failure branches (drift / bad value) — no spurious output on successful checkpoints except the begin/done/EXIT lines

## Zero-cost verification

With flag OFF, the macro body is preprocessed away — the compiler never sees the fprintf call or its arguments. Verified by inspecting the optimizer-friendly `((void)0)` expansion; the one extra `#include "common/debug_log.h"` adds no code and no runtime work.

## Follow-ups (out of scope)

- Could add sibling macros (`KUZU_DEBUG_PLAN`, `KUZU_DEBUG_HNSW`) for other subsystems if we hit them. Same pattern, same `debug_log.h`.
- Documentation in `docs/debugging.md` — happy to add if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)