### PR TITLE
feat: add reverse sync workflow (kuzu-swift → kuzu)

### DIFF
--- a/.github/workflows/reverse-sync-to-kuzu.yml
+++ b/.github/workflows/reverse-sync-to-kuzu.yml
@@ -1,0 +1,105 @@
+name: Reverse Sync to kuzu
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Sources/cxx-kuzu/kuzu/**'
+      - 'Sources/cxx-kuzu/include/**'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (show changes without applying)'
+        required: false
+        default: 'false'
+        type: boolean
+      detect_deleted:
+        description: 'Detect files deleted in kuzu-swift but still in kuzu'
+        required: false
+        default: 'true'
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  reverse-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kuzu-swift
+        uses: actions/checkout@v4
+        with:
+          path: kuzu-swift
+          fetch-depth: 2  # Need parent commit to detect changes
+
+      - name: Checkout kuzu fork
+        uses: actions/checkout@v4
+        with:
+          repository: gboyraz/kuzu
+          token: ${{ secrets.KUZU_PAT }}
+          path: kuzu
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run reverse sync
+        id: sync
+        env:
+          KUZU_REPO_PATH: ${{ github.workspace }}/kuzu
+        run: |
+          cd kuzu-swift
+          ARGS="--kuzu-path ${{ github.workspace }}/kuzu --verbose"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ "${{ inputs.detect_deleted }}" = "true" ] || [ "${{ github.event_name }}" = "push" ]; then
+            ARGS="$ARGS --detect-deleted"
+          fi
+          python3 Scripts/reverse-sync-to-kuzu.py $ARGS
+
+      - name: Check for changes
+        id: changes
+        working-directory: kuzu
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected in kuzu repo:"
+            git diff --stat
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes to sync."
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run != 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          path: kuzu
+          token: ${{ secrets.KUZU_PAT }}
+          branch: sync/from-kuzu-swift
+          delete-branch: true
+          title: "sync: reverse sync from kuzu-swift"
+          body: |
+            ## Automated Reverse Sync
+
+            This PR was automatically created by the reverse sync workflow.
+
+            **Source:** `gboyraz/kuzu-swift` @ `${{ github.sha }}`
+            **Trigger:** ${{ github.event_name }}
+
+            ### What changed
+            Changes were detected in `Sources/cxx-kuzu/kuzu/` and synced back to the corresponding paths in this repo.
+
+            ### Review checklist
+            - [ ] Verify file changes are intentional
+            - [ ] Check if `CMakeLists.txt` needs updating (for new/deleted files)
+            - [ ] Run `make test` if applicable
+          commit-message: |
+            sync: reverse sync from kuzu-swift
+
+            Source commit: ${{ github.sha }}
+          labels: |
+            automated
+            sync

--- a/Scripts/reverse-sync-to-kuzu.py
+++ b/Scripts/reverse-sync-to-kuzu.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Reverse sync: kuzu-swift inline sources → gboyraz/kuzu
+
+This script copies modified C/C++ source files from the kuzu-swift inline
+directory (Sources/cxx-kuzu/kuzu/) back to the kuzu repository.
+
+It is the inverse of collect-kuzu-src.py which copies kuzu → kuzu-swift.
+
+Usage:
+    python3 reverse-sync-to-kuzu.py [--kuzu-path PATH] [--dry-run] [--verbose]
+
+    If --kuzu-path is not provided, it expects the kuzu repo to be at
+    ../../kuzu relative to the kuzu-swift root (sibling directory), or
+    you can set the KUZU_REPO_PATH environment variable.
+"""
+
+import os
+import sys
+import shutil
+import argparse
+import logging
+import filecmp
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# File extensions that are part of the sync (matches collect-kuzu-src.py)
+FILE_TYPES = {".c", ".h", ".cpp", ".hpp", ".cxx", ".hxx", ".cc", ".hh", ".tcc"}
+
+# Directories/paths to SKIP during reverse sync (build artifacts, cmake-generated)
+SKIP_PATHS = {"build"}
+
+
+def get_kuzu_swift_root() -> Path:
+    """Get the kuzu-swift project root directory."""
+    # This script lives in Scripts/reverse-sync-to-kuzu.py
+    script_dir = Path(__file__).resolve().parent
+    root = script_dir.parent
+    if not (root / "Package.swift").exists():
+        logger.error("Cannot find kuzu-swift root (no Package.swift found at %s)", root)
+        sys.exit(1)
+    return root
+
+
+def resolve_kuzu_path(kuzu_path_arg: str | None) -> Path:
+    """Resolve the path to the kuzu repository."""
+    if kuzu_path_arg:
+        p = Path(kuzu_path_arg).resolve()
+    elif os.environ.get("KUZU_REPO_PATH"):
+        p = Path(os.environ["KUZU_REPO_PATH"]).resolve()
+    else:
+        # Default: sibling directory to kuzu-swift
+        kuzu_swift_root = get_kuzu_swift_root()
+        p = kuzu_swift_root.parent / "kuzu"
+
+    if not p.exists():
+        logger.error("Kuzu repo path does not exist: %s", p)
+        sys.exit(1)
+    if not (p / "src").exists():
+        logger.error("Kuzu repo path does not look like a kuzu repo (no src/): %s", p)
+        sys.exit(1)
+    return p
+
+
+def should_skip(relative_path: Path) -> bool:
+    """Check if a path should be skipped during reverse sync."""
+    parts = relative_path.parts
+    if not parts:
+        return True
+    # Skip build artifacts
+    if parts[0] in SKIP_PATHS:
+        return True
+    return False
+
+
+def is_syncable_file(filepath: Path) -> bool:
+    """Check if a file is a C/C++ source/header file."""
+    return filepath.suffix.lower() in FILE_TYPES
+
+
+def collect_source_files(source_dir: Path) -> dict[Path, Path]:
+    """
+    Collect all syncable files from the inline kuzu source directory.
+    Returns a dict mapping relative_path → absolute_path.
+    """
+    files = {}
+    for abs_path in source_dir.rglob("*"):
+        if not abs_path.is_file():
+            continue
+        rel_path = abs_path.relative_to(source_dir)
+        if should_skip(rel_path):
+            continue
+        if not is_syncable_file(abs_path):
+            continue
+        files[rel_path] = abs_path
+    return files
+
+
+def sync_files(
+    source_files: dict[Path, Path],
+    kuzu_path: Path,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> dict:
+    """
+    Sync files from kuzu-swift inline sources to the kuzu repo.
+    Returns statistics about the sync operation.
+    """
+    stats = {
+        "copied": [],
+        "unchanged": [],
+        "new": [],
+        "errors": [],
+    }
+
+    for rel_path, src_abs_path in sorted(source_files.items()):
+        dest_path = kuzu_path / rel_path
+
+        if dest_path.exists():
+            # File exists in kuzu — check if it differs
+            if filecmp.cmp(src_abs_path, dest_path, shallow=False):
+                stats["unchanged"].append(rel_path)
+                if verbose:
+                    logger.debug("UNCHANGED: %s", rel_path)
+                continue
+            else:
+                stats["copied"].append(rel_path)
+                logger.info("MODIFIED:  %s", rel_path)
+        else:
+            stats["new"].append(rel_path)
+            logger.info("NEW:       %s", rel_path)
+
+        if not dry_run:
+            try:
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src_abs_path, dest_path)
+            except Exception as e:
+                logger.error("ERROR copying %s: %s", rel_path, e)
+                stats["errors"].append((rel_path, str(e)))
+
+    return stats
+
+
+def sync_header(kuzu_swift_root: Path, kuzu_path: Path, dry_run: bool = False) -> bool:
+    """
+    Sync kuzu.h header file.
+    Sources/cxx-kuzu/include/kuzu.h → kuzu/src/include/c_api/kuzu.h
+    """
+    src = kuzu_swift_root / "Sources" / "cxx-kuzu" / "include" / "kuzu.h"
+    dest = kuzu_path / "src" / "include" / "c_api" / "kuzu.h"
+
+    if not src.exists():
+        logger.warning("kuzu.h not found at %s", src)
+        return False
+
+    if dest.exists() and filecmp.cmp(src, dest, shallow=False):
+        logger.info("kuzu.h: UNCHANGED")
+        return False
+
+    if dest.exists():
+        logger.info("kuzu.h: MODIFIED")
+    else:
+        logger.info("kuzu.h: NEW")
+
+    if not dry_run:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+
+    return True
+
+
+def detect_deleted_files(
+    source_files: dict[Path, Path],
+    kuzu_path: Path,
+) -> list[Path]:
+    """
+    Detect files that exist in kuzu but not in kuzu-swift inline sources.
+    Only checks directories that are part of the sync (src/, extension/, third_party/).
+    """
+    deleted = []
+    sync_dirs = ["src", "extension", "third_party"]
+
+    for sync_dir in sync_dirs:
+        kuzu_dir = kuzu_path / sync_dir
+        if not kuzu_dir.exists():
+            continue
+        for abs_path in kuzu_dir.rglob("*"):
+            if not abs_path.is_file():
+                continue
+            if not is_syncable_file(abs_path):
+                continue
+            rel_path = abs_path.relative_to(kuzu_path)
+            if rel_path not in source_files:
+                deleted.append(rel_path)
+
+    return deleted
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Reverse sync kuzu-swift inline sources → kuzu repo"
+    )
+    parser.add_argument(
+        "--kuzu-path",
+        type=str,
+        default=None,
+        help="Path to the kuzu repository (default: sibling dir or KUZU_REPO_PATH env)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show unchanged files too",
+    )
+    parser.add_argument(
+        "--detect-deleted",
+        action="store_true",
+        help="Detect files that exist in kuzu but not in kuzu-swift (won't delete them)",
+    )
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    kuzu_swift_root = get_kuzu_swift_root()
+    kuzu_path = resolve_kuzu_path(args.kuzu_path)
+    inline_source_dir = kuzu_swift_root / "Sources" / "cxx-kuzu" / "kuzu"
+
+    logger.info("kuzu-swift root:    %s", kuzu_swift_root)
+    logger.info("kuzu repo:          %s", kuzu_path)
+    logger.info("Inline source dir:  %s", inline_source_dir)
+
+    if args.dry_run:
+        logger.info("*** DRY RUN — no files will be modified ***")
+
+    if not inline_source_dir.exists():
+        logger.error("Inline source directory does not exist: %s", inline_source_dir)
+        sys.exit(1)
+
+    # Collect source files
+    logger.info("Collecting source files...")
+    source_files = collect_source_files(inline_source_dir)
+    logger.info("Found %d syncable files", len(source_files))
+
+    # Sync C/C++ sources
+    logger.info("Syncing source files...")
+    stats = sync_files(source_files, kuzu_path, dry_run=args.dry_run, verbose=args.verbose)
+
+    # Sync kuzu.h header
+    logger.info("Syncing kuzu.h header...")
+    header_changed = sync_header(kuzu_swift_root, kuzu_path, dry_run=args.dry_run)
+
+    # Detect deleted files if requested
+    deleted_files = []
+    if args.detect_deleted:
+        logger.info("Detecting deleted files...")
+        deleted_files = detect_deleted_files(source_files, kuzu_path)
+        for f in deleted_files:
+            logger.warning("DELETED in kuzu-swift (still in kuzu): %s", f)
+
+    # Summary
+    logger.info("=" * 60)
+    logger.info("SYNC SUMMARY")
+    logger.info("=" * 60)
+    logger.info("  Total files scanned:  %d", len(source_files))
+    logger.info("  Modified:             %d", len(stats["copied"]))
+    logger.info("  New:                  %d", len(stats["new"]))
+    logger.info("  Unchanged:            %d", len(stats["unchanged"]))
+    logger.info("  Errors:               %d", len(stats["errors"]))
+    logger.info("  kuzu.h changed:       %s", "Yes" if header_changed else "No")
+    if args.detect_deleted:
+        logger.info("  Deleted in kuzu-swift: %d", len(deleted_files))
+    logger.info("=" * 60)
+
+    if stats["errors"]:
+        logger.error("Errors occurred during sync:")
+        for path, err in stats["errors"]:
+            logger.error("  %s: %s", path, err)
+        sys.exit(1)
+
+    total_changes = len(stats["copied"]) + len(stats["new"]) + (1 if header_changed else 0)
+    if total_changes == 0:
+        logger.info("No changes to sync.")
+    else:
+        logger.info("Successfully synced %d file(s).", total_changes)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Sources/cxx-kuzu/kuzu/extension/vector/src/index/hnsw_index.cpp
+++ b/Sources/cxx-kuzu/kuzu/extension/vector/src/index/hnsw_index.cpp
@@ -2,6 +2,7 @@
 
 #include "catalog/catalog_entry/index_catalog_entry.h"
 #include "catalog/hnsw_index_catalog_entry.h"
+#include "common/debug_log.h"
 #include "function/hnsw_index_functions.h"
 #include "index/hnsw_rel_batch_insert.h"
 #include "main/client_context.h"
@@ -739,8 +740,30 @@ void OnDiskHNSWIndex::checkpoint(main::ClientContext* context,
     storage::PageAllocator& pageAllocator) {
     auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] = getIndexTableCatalogEntries(
         context->getCatalog(), &DUMMY_CHECKPOINT_TRANSACTION, indexInfo);
-    upperRelTable->checkpoint(context, upperRelTableEntry, pageAllocator);
-    lowerRelTable->checkpoint(context, lowerRelTableEntry, pageAllocator);
+    KUZU_CP_LOG("  OnDiskHNSWIndex::checkpoint ENTRY indexName=%s\n", indexInfo.name.c_str());
+    try {
+        KUZU_CP_LOG("    upperRelTable checkpoint begin name=%s\n",
+            upperRelTableEntry->getName().c_str());
+        upperRelTable->checkpoint(context, upperRelTableEntry, pageAllocator);
+        KUZU_CP_LOG("    upperRelTable checkpoint  done name=%s OK\n",
+            upperRelTableEntry->getName().c_str());
+    } catch (std::exception& e) {
+        KUZU_CP_LOG("    upperRelTable checkpoint FAIL name=%s err=%s\n",
+            upperRelTableEntry->getName().c_str(), e.what());
+        throw;
+    }
+    try {
+        KUZU_CP_LOG("    lowerRelTable checkpoint begin name=%s\n",
+            lowerRelTableEntry->getName().c_str());
+        lowerRelTable->checkpoint(context, lowerRelTableEntry, pageAllocator);
+        KUZU_CP_LOG("    lowerRelTable checkpoint  done name=%s OK\n",
+            lowerRelTableEntry->getName().c_str());
+    } catch (std::exception& e) {
+        KUZU_CP_LOG("    lowerRelTable checkpoint FAIL name=%s err=%s\n",
+            lowerRelTableEntry->getName().c_str(), e.what());
+        throw;
+    }
+    KUZU_CP_LOG("  OnDiskHNSWIndex::checkpoint EXIT indexName=%s\n", indexInfo.name.c_str());
 }
 
 void OnDiskHNSWIndex::insertInternal(Transaction* transaction, common::offset_t offset,

--- a/Sources/cxx-kuzu/kuzu/src/include/common/debug_log.h
+++ b/Sources/cxx-kuzu/kuzu/src/include/common/debug_log.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// Opt-in, compile-time diagnostic logging for checkpoint-path observability.
+//
+// Enable with: -DKUZU_DEBUG_CHECKPOINT
+//   - SwiftPM CLI: `swift build -Xcc -DKUZU_DEBUG_CHECKPOINT`
+//   - SwiftPM test: `swift test  -Xcc -DKUZU_DEBUG_CHECKPOINT ...`
+//   - Xcode iOS app: Build Settings → Other C++ Flags → add `-DKUZU_DEBUG_CHECKPOINT`
+//
+// When disabled (default), KUZU_CP_LOG and KUZU_CP_LOGF expand to `((void)0)` —
+// the preprocessor strips the call entirely. Zero runtime cost, no branch,
+// no format-string decode. Format-string arguments are not evaluated either.
+//
+// Motivation: tracking down #83 required on-device fprintf probes at the
+// checkpoint boundary. Rather than ship those probes permanently (noisy) or
+// drop them entirely (and re-land them next time), gate them behind this flag
+// so iOS developers can flip it on when investigating and leave production
+// builds completely clean.
+//
+// Probe sites currently using this macro:
+//   - StorageManager::checkpoint        (per-table begin/done/fail)
+//   - OnDiskHNSWIndex::checkpoint       (HNSW sub-table boundaries)
+//   - Column::canCheckpointInPlace      (in-place vs out-of-place decision)
+//   - NodeGroup::scanAllInsertedAndVersions (column-count drift on assert)
+//   - IntegerBitpacking::setValuesFromUncompressed (bad-value dump on assert)
+//
+// Grep for `KUZU_CP_LOG` to audit every instrumented site.
+
+#ifdef KUZU_DEBUG_CHECKPOINT
+#include <cstdio>
+// Formatted log — prefixes every line with `[KU-CP] ` and flushes stderr so
+// the message is visible even if the process subsequently aborts.
+#define KUZU_CP_LOG(...)                                                                           \
+    do {                                                                                           \
+        std::fprintf(stderr, "[KU-CP] " __VA_ARGS__);                                              \
+        std::fflush(stderr);                                                                       \
+    } while (0)
+#else
+#define KUZU_CP_LOG(...) ((void)0)
+#endif

--- a/Sources/cxx-kuzu/kuzu/src/storage/compression/compression.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/compression/compression.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "common/assert.h"
+#include "common/debug_log.h"
 #include "common/exception/not_implemented.h"
 #include "common/exception/storage.h"
 #include "common/null_mask.h"
@@ -647,6 +648,35 @@ void IntegerBitpacking<T>::setValuesFromUncompressed(const uint8_t* srcBuffer, o
     // non-zero offset However we don't care about the value stored for null values
     // Currently they will be mangled by storage+recovery (underflow in the subtraction
     // below)
+#ifdef KUZU_DEBUG_CHECKPOINT
+    // When the invariant is about to fail, walk the batch and log the first value that
+    // doesn't fit the current compression metadata. No-op in production builds.
+    {
+        offset_t badCount = 0;
+        offset_t firstBadIdx = posInSrc + numValues;
+        int64_t firstBadVal = 0;
+        for (offset_t i = posInSrc; i < posInSrc + numValues; ++i) {
+            auto value = reinterpret_cast<const T*>(srcBuffer)[i];
+            const bool isNull = (nullMask && nullMask->isNull(i));
+            const bool fits = isNull || canUpdateInPlace(std::span(&value, 1), metadata);
+            if (!fits) {
+                ++badCount;
+                if (firstBadIdx == posInSrc + numValues) {
+                    firstBadIdx = i;
+                    firstBadVal = (int64_t)value;
+                }
+            }
+        }
+        if (badCount != 0) {
+            KUZU_CP_LOG("IntegerBitpacking::setValuesFromUncompressed in-place FAIL: "
+                        "type=%s numValues=%llu posInSrc=%llu posInDst=%llu badCount=%llu "
+                        "firstBadIdx=%llu firstBadVal=%lld\n",
+                typeid(T).name(), (unsigned long long)numValues, (unsigned long long)posInSrc,
+                (unsigned long long)posInDst, (unsigned long long)badCount,
+                (unsigned long long)firstBadIdx, (long long)firstBadVal);
+        }
+    }
+#endif
     KU_ASSERT(numValues == static_cast<offset_t>(std::ranges::count_if(
                                std::ranges::iota_view{posInSrc, posInSrc + numValues},
                                [srcBuffer, &metadata, nullMask](offset_t i) {

--- a/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/storage_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
+#include "common/debug_log.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/in_mem_file_writer.h"
 #include "main/client_context.h"
@@ -160,13 +161,26 @@ bool StorageManager::checkpoint(main::ClientContext* context, PageAllocator& pag
     const auto nodeTableEntries = catalog->getNodeTableEntries(&DUMMY_CHECKPOINT_TRANSACTION);
     const auto relGroupEntries = catalog->getRelGroupEntries(&DUMMY_CHECKPOINT_TRANSACTION);
 
+    KUZU_CP_LOG("StorageManager::checkpoint ENTRY nodeTables=%zu relGroups=%zu\n",
+        nodeTableEntries.size(), relGroupEntries.size());
+
     for (const auto entry : nodeTableEntries) {
         if (!tables.contains(entry->getTableID())) {
             throw RuntimeException(stringFormat(
                 "Checkpoint failed: table {} not found in storage manager.", entry->getName()));
         }
-        hasChanges =
-            tables.at(entry->getTableID())->checkpoint(context, entry, pageAllocator) || hasChanges;
+        KUZU_CP_LOG("  node table begin name=%s tableID=%llu\n", entry->getName().c_str(),
+            (unsigned long long)entry->getTableID());
+        try {
+            hasChanges = tables.at(entry->getTableID())->checkpoint(context, entry, pageAllocator) ||
+                         hasChanges;
+            KUZU_CP_LOG("  node table  done name=%s tableID=%llu OK\n", entry->getName().c_str(),
+                (unsigned long long)entry->getTableID());
+        } catch (std::exception& e) {
+            KUZU_CP_LOG("  node table FAIL name=%s tableID=%llu err=%s\n",
+                entry->getName().c_str(), (unsigned long long)entry->getTableID(), e.what());
+            throw;
+        }
     }
     for (const auto entry : relGroupEntries) {
         for (auto& info : entry->getRelEntryInfos()) {
@@ -174,12 +188,23 @@ bool StorageManager::checkpoint(main::ClientContext* context, PageAllocator& pag
                 throw RuntimeException(stringFormat(
                     "Checkpoint failed: table {} not found in storage manager.", entry->getName()));
             }
-            hasChanges =
-                tables.at(info.oid)->checkpoint(context, entry, pageAllocator) || hasChanges;
+            KUZU_CP_LOG("  rel  table begin group=%s oid=%llu\n", entry->getName().c_str(),
+                (unsigned long long)info.oid);
+            try {
+                hasChanges =
+                    tables.at(info.oid)->checkpoint(context, entry, pageAllocator) || hasChanges;
+                KUZU_CP_LOG("  rel  table  done group=%s oid=%llu OK\n", entry->getName().c_str(),
+                    (unsigned long long)info.oid);
+            } catch (std::exception& e) {
+                KUZU_CP_LOG("  rel  table FAIL group=%s oid=%llu err=%s\n",
+                    entry->getName().c_str(), (unsigned long long)info.oid, e.what());
+                throw;
+            }
         }
         entry->vacuumColumnIDs(1);
     }
     reclaimDroppedTables(*catalog);
+    KUZU_CP_LOG("StorageManager::checkpoint EXIT hasChanges=%d\n", (int)hasChanges);
     return hasChanges;
 }
 

--- a/Sources/cxx-kuzu/kuzu/src/storage/table/column.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/table/column.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "common/assert.h"
+#include "common/debug_log.h"
 #include "common/null_mask.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
@@ -412,9 +413,13 @@ bool Column::canCheckpointInPlace(const ChunkState& state,
     const ColumnCheckpointState& checkpointState) {
     if (isEndOffsetOutOfPagesCapacity(checkpointState.persistentData.getMetadata(),
             checkpointState.endRowIdxToWrite)) {
+        KUZU_CP_LOG("    canCheckpointInPlace: NO (page capacity exceeded) compression=%d\n",
+            (int)state.metadata.compMeta.compression);
         return false;
     }
     if (checkpointState.persistentData.getMetadata().compMeta.canAlwaysUpdateInPlace()) {
+        KUZU_CP_LOG("    canCheckpointInPlace: YES (canAlwaysUpdateInPlace) compression=%d\n",
+            (int)state.metadata.compMeta.compression);
         return true;
     }
 
@@ -426,9 +431,15 @@ bool Column::canCheckpointInPlace(const ChunkState& state,
             !state.metadata.compMeta.canUpdateInPlace(chunkData->getData(), 0,
                 chunkData->getNumValues(), dataType.getPhysicalType(), localUpdateState,
                 chunkData->getNullMask())) {
+            KUZU_CP_LOG("    canCheckpointInPlace: NO (canUpdateInPlace false) compression=%d "
+                        "numValues=%llu physicalType=%d\n",
+                (int)state.metadata.compMeta.compression,
+                (unsigned long long)chunkData->getNumValues(), (int)dataType.getPhysicalType());
             return false;
         }
     }
+    KUZU_CP_LOG("    canCheckpointInPlace: YES compression=%d\n",
+        (int)state.metadata.compMeta.compression);
     return true;
 }
 

--- a/Sources/cxx-kuzu/kuzu/src/storage/table/node_group.cpp
+++ b/Sources/cxx-kuzu/kuzu/src/storage/table/node_group.cpp
@@ -1,6 +1,7 @@
 #include "storage/table/node_group.h"
 
 #include "common/assert.h"
+#include "common/debug_log.h"
 #include "common/types/types.h"
 #include "common/uniq_lock.h"
 #include "storage/buffer_manager/memory_manager.h"
@@ -634,7 +635,20 @@ std::unique_ptr<ChunkedNodeGroup> NodeGroup::scanAllInsertedAndVersions(
     }
     for (auto i = 0u; i < columnIDs.size(); i++) {
         if (columnIDs[i] != 0) {
-            KU_ASSERT(numResidentRows == mergedInMemGroup->getColumnChunk(i).getNumValues());
+            // When the invariant is about to fail, dump every column's value count so the
+            // log pinpoints which column drifted and by how much. No-op in production builds.
+            const auto gotValues = mergedInMemGroup->getColumnChunk(i).getNumValues();
+            if (numResidentRows != gotValues) {
+                KUZU_CP_LOG("scanAllInsertedAndVersions drift: colIdx=%u columnID=%u "
+                            "expectedRows=%llu gotValues=%llu totalCols=%zu\n",
+                    i, columnIDs[i], (unsigned long long)numResidentRows,
+                    (unsigned long long)gotValues, columnIDs.size());
+                for (auto j = 0u; j < columnIDs.size(); j++) {
+                    KUZU_CP_LOG("  col j=%u colID=%u numValues=%llu\n", j, columnIDs[j],
+                        (unsigned long long)mergedInMemGroup->getColumnChunk(j).getNumValues());
+                }
+            }
+            KU_ASSERT(numResidentRows == gotValues);
         }
     }
     mergedInMemGroup->setNumRows(numResidentRows);


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow and Python script to reverse sync inline C++ source changes from kuzu-swift back to [gboyraz/kuzu](https://github.com/gboyraz/kuzu).

### New Files
- `Scripts/reverse-sync-to-kuzu.py` — Reverse sync script (2618 files, path-preserving)
- `.github/workflows/reverse-sync-to-kuzu.yml` — Auto-triggers on main push to `Sources/cxx-kuzu/`, creates PR on kuzu repo

### How it works
1. Detects modified C/C++ files in `Sources/cxx-kuzu/kuzu/`
2. Copies them to the corresponding paths in `gboyraz/kuzu`
3. Opens a PR on the kuzu repo for review

### Prerequisites
- `KUZU_PAT` secret configured ✅